### PR TITLE
cleanup / fix gemspec

### DIFF
--- a/diplomat.gemspec
+++ b/diplomat.gemspec
@@ -1,30 +1,22 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'diplomat/version'
+require './lib/diplomat/version'
 
-Gem::Specification.new do |spec|
-  spec.name          = "diplomat"
-  spec.version       = Diplomat::VERSION
+Gem::Specification.new "diplomat", Diplomat::VERSION do |spec|
   spec.authors       = ["John Hamelink"]
   spec.email         = ["john@johnhamelink.com"]
-  spec.description   = %q{Diplomat is a simple wrapper for Consul}
-  spec.summary       = %q{Diplomat is a simple wrapper for Consul}
+  spec.description   = spec.summary = "Diplomat is a simple wrapper for Consul"
   spec.homepage      = "https://github.com/johnhamelink/diplomat"
   spec.license       = "BSD"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  spec.files         = `git ls-files lib README.md LICENSE`.split($/)
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.3"
   spec.add_development_dependency "pry", "~> 0.9"
   spec.add_development_dependency "rspec", "~> 2.14"
   spec.add_development_dependency "fakes-rspec", "~> 1.0"
-  spec.add_development_dependency "json", "~> 1.8"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.3.0"
-  spec.add_dependency "faraday", "~> 0.9"
-  spec.add_dependency "fivemat"
+  spec.add_development_dependency "fivemat"
+
+  spec.add_runtime_dependency "json", "~> 1.8"
+  spec.add_runtime_dependency "faraday", "~> 0.9"
 end


### PR DESCRIPTION
@johnhamelink @hunter 
- remove unnecessary encoding / lib / load-path
- ship less files -> smaller/ligher gem
- json is a runtime dependency
- fivemat is not a runtime dependency
