### PR TITLE
Add options and meta data return for service get calls

### DIFF
--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -7,9 +7,29 @@ module Diplomat
     # Get a service by it's key
     # @param key [String] the key
     # @param scope [Symbol] :first or :all results
+    # @param options [Hash] :wait string for wait time and :index for index of last query
+    # @param meta [Hash] output structure containing header information about the request (index)
     # @return [OpenStruct] all data associated with the service
-    def get key, scope=:first
-      ret = @conn.get "/v1/catalog/service/#{key}"
+    def get key, scope=:first, options=nil, meta=nil
+
+      qs = ""
+      sep = "?"
+      if options and options[:wait]
+        qs = "#{qs}#{sep}wait=#{options[:wait]}"
+        sep = "&"
+      end
+      if options and options[:index]
+        qs = "#{qs}#{sep}index=#{options[:index]}"
+        sep = "&"
+      end
+
+      ret = @conn.get "/v1/catalog/service/#{key}#{qs}"
+
+      if meta and ret.headers
+        meta[:index] = ret.headers["x-consul-index"]
+        meta[:knownleader] = ret.headers["x-consul-knownleader"]
+        meta[:lastcontact] = ret.headers["x-consul-lastcontact"]
+      end
 
       if scope == :all
         return JSON.parse(ret.body).map { |service| OpenStruct.new service }

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe Diplomat do
 
   describe "configuration" do
+    before(:each) do
+      expect(Diplomat.configuration).to_not be_nil
+      expect(Diplomat.configuration).to be_a Diplomat::Configuration
+      Diplomat.configuration = Diplomat::Configuration.new
+    end
 
     it "has configuration block"  do
       expect { |b| Diplomat.configure(&b) }.to yield_control

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -9,6 +9,9 @@ describe Diplomat::Service do
   context "services" do
     let(:key) { "toast" }
     let(:key_url) { "/v1/catalog/service/#{key}" }
+    let(:key_url_with_alloptions) { "/v1/catalog/service/#{key}?wait=5m&index=3" }
+    let(:key_url_with_indexoption) { "/v1/catalog/service/#{key}?index=5" }
+    let(:key_url_with_waitoption) { "/v1/catalog/service/#{key}?wait=6s" }
     let(:body) {
       [
         {
@@ -29,12 +32,19 @@ describe Diplomat::Service do
         }
       ]
     }
+    let(:headers) {
+      {
+        "x-consul-index"        => "8",
+        "x-consul-knownleader"  => "true",
+        "x-consul-lastcontact"  => "0"
+      }
+    }
 
     describe "GET" do
       it ":first" do
         json = JSON.generate(body)
 
-        faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json }))
 
         service = Diplomat::Service.new(faraday)
 
@@ -44,12 +54,78 @@ describe Diplomat::Service do
       it ":all" do
         json = JSON.generate(body)
 
-        faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json }))
 
         service = Diplomat::Service.new(faraday)
 
         expect(service.get("toast", :all).size).to eq(2)
         expect(service.get("toast", :all)[0].Node).to eq("foo")
+      end
+    end
+
+    describe "GET With Options" do
+      it "empty headers" do
+        json = JSON.generate(body)
+
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json, headers: nil }))
+
+        service = Diplomat::Service.new(faraday)
+
+        meta = {}
+        s = service.get("toast", :first, {}, meta)
+        expect(s.Node).to eq("foo")
+        expect(meta.length).to eq(0)
+      end
+
+      it "filled headers" do
+        json = JSON.generate(body)
+
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json, headers: headers }))
+
+        service = Diplomat::Service.new(faraday)
+
+        meta = {}
+        s = service.get("toast", :first, {}, meta)
+        expect(s.Node).to eq("foo")
+        expect(meta[:index]).to eq("8")
+        expect(meta[:knownleader]).to eq("true")
+        expect(meta[:lastcontact]).to eq("0")
+      end
+
+      it "index option" do
+        json = JSON.generate(body)
+
+        faraday.stub(:get).with(key_url_with_indexoption).and_return(OpenStruct.new({ body: json, headers: headers }))
+
+        service = Diplomat::Service.new(faraday)
+
+        options = { :index => "5" }
+        s = service.get("toast", :first, options)
+        expect(s.Node).to eq("foo")
+      end
+
+      it "wait option" do
+        json = JSON.generate(body)
+
+        faraday.stub(:get).with(key_url_with_waitoption).and_return(OpenStruct.new({ body: json, headers: headers }))
+
+        service = Diplomat::Service.new(faraday)
+
+        options = { :wait => "6s" }
+        s = service.get("toast", :first, options)
+        expect(s.Node).to eq("foo")
+      end
+
+      it "both options" do
+        json = JSON.generate(body)
+
+        faraday.stub(:get).with(key_url_with_alloptions).and_return(OpenStruct.new({ body: json, headers: headers }))
+
+        service = Diplomat::Service.new(faraday)
+
+        options = { :wait => "5m", :index => "3" }
+        s = service.get("toast", :first, options)
+        expect(s.Node).to eq("foo")
       end
     end
 


### PR DESCRIPTION
Here is a start for adding the ability to send in options and get back meta data about requests.
This is for the service get function.  If y'all are good with this pattern, I'll look into adding the others. 

I don't know the others just yet for my project, but I will.

