### PR TITLE
Added support for acl_token in K/V store

### DIFF
--- a/lib/diplomat/configuration.rb
+++ b/lib/diplomat/configuration.rb
@@ -5,7 +5,7 @@ module Diplomat
 
     def initialize(url="http://localhost:8500", acl_token=nil)
       @middleware = []
-      @url = "http://localhost:8500"
+      @url = url
       @acl_token = acl_token
     end
 

--- a/lib/diplomat/configuration.rb
+++ b/lib/diplomat/configuration.rb
@@ -1,11 +1,12 @@
 module Diplomat
   class Configuration
     attr_accessor :middleware
-    attr_accessor :url
+    attr_accessor :url, :acl_token
 
-    def initialize
+    def initialize(url="http://localhost:8500", acl_token=nil)
       @middleware = []
       @url = "http://localhost:8500"
+      @acl_token = acl_token
     end
 
     def middleware=(middleware)

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -27,12 +27,6 @@ module Diplomat
     def put key, value, options=nil
       qs = ""
       @options = options
-      # if options and options[:cas]
-        #qs = "?cas=#{options[:cas]}" if options && options[:cas]
-        #qs = use_cas(options)  #unless use_cas(options).nil?
-      # end
-
-      # @raw = @conn.put("/v1/kv/#{key}#{qs}", value)
       @raw = @conn.put do |req|
         args = ["/v1/kv/#{key}"]
         args += check_acl_token unless check_acl_token.nil?
@@ -45,7 +39,6 @@ module Diplomat
         @key   = key
         @value = value
       else
-      # return @value
         @raw.body
       end
     end

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -11,7 +11,9 @@ module Diplomat
     # @return [String] The base64-decoded value associated with the key
     def get key
       @key = key
-      @raw = @conn.get "/v1/kv/#{@key}"
+      args = ["/v1/kv/#{@key}"]
+      args += check_acl_token unless check_acl_token.nil?
+      @raw = @conn.get args.join
       parse_body
       return_value
     end
@@ -24,18 +26,28 @@ module Diplomat
     # @return [String] The base64-decoded value associated with the key
     def put key, value, options=nil
       qs = ""
+      @options = options
+      # if options and options[:cas]
+        #qs = "?cas=#{options[:cas]}" if options && options[:cas]
+        #qs = use_cas(options)  #unless use_cas(options).nil?
+      # end
 
-      if options and options[:cas]
-        qs = "?cas=#{options[:cas]}"
+      # @raw = @conn.put("/v1/kv/#{key}#{qs}", value)
+      @raw = @conn.put do |req|
+        args = ["/v1/kv/#{key}"]
+        args += check_acl_token unless check_acl_token.nil?
+        args += use_cas(@options) unless use_cas(@options).nil?
+        puts args.join
+        req.url args.join
+        req.body = value
       end
-
-      @raw = @conn.put("/v1/kv/#{key}#{qs}", value)
-
       if @raw.body == "true\n"
         @key   = key
         @value = value
+      else
+      # return @value
+        @raw.body
       end
-      return @value
     end
 
     # Delete a value by it's key
@@ -81,5 +93,12 @@ module Diplomat
       @value = Base64.decode64(@value) unless @value.nil?
     end
 
+    def check_acl_token
+      ["?token=#{Diplomat.configuration.acl_token}"] if Diplomat.configuration.acl_token
+    end
+
+    def use_cas(options)
+      ["&cas=#{options[:cas]}"] if options && options[:cas]
+    end
   end
 end

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -31,7 +31,6 @@ module Diplomat
         args = ["/v1/kv/#{key}"]
         args += check_acl_token unless check_acl_token.nil?
         args += use_cas(@options) unless use_cas(@options).nil?
-        puts args.join
         req.url args.join
         req.body = value
       end
@@ -48,9 +47,11 @@ module Diplomat
     # @return [nil]
     def delete key
       @key = key
-      @raw = @conn.delete "/v1/kv/#{@key}"
-      return_key
-      return_value
+      args = ["/v1/kv/#{@key}"]
+      args += check_acl_token unless check_acl_token.nil?
+      @raw = @conn.delete args.join
+      # return_key
+      # return_value
     end
 
     # @note This is sugar, see (#get)

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -46,10 +46,12 @@ describe Diplomat do
       it "Sets the correct configuration" do
         Diplomat.configure do |config|
           config.url = "http://google.com"
+          config.acl_token = "f45cbd0b-5022-47ab-8640-4eaa7c1f40f1"
           config.middleware = StubMiddleware
         end
 
         expect(Diplomat.configuration.url).to eq("http://google.com")
+        expect(Diplomat.configuration.acl_token).to eq("f45cbd0b-5022-47ab-8640-4eaa7c1f40f1")
         expect(Diplomat.configuration.middleware).to be_a(Array)
         expect(Diplomat.configuration.middleware.first).to eq(StubMiddleware)
       end

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -21,11 +21,8 @@ describe Diplomat::Kv do
             "Value" => Base64.encode64(key_params),
             "Flags" => 0
           }])
-
           faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
-
           kv = Diplomat::Kv.new(faraday)
-
           expect(kv.get("key")).to eq("toast")
         end
       end    
@@ -36,10 +33,8 @@ describe Diplomat::Kv do
             "Value" => Base64.encode64("Faraday::ResourceNotFound: the server responded with status 404"),
             "Flags" => 0
           }])
-
           faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
           kv = Diplomat::Kv.new(faraday)
-
           expect(kv.get("key")).to eq("Faraday::ResourceNotFound: the server responded with status 404")
         end
       end
@@ -50,14 +45,10 @@ describe Diplomat::Kv do
             "Value" => Base64.encode64(key_params),
             "Flags" => 0
           }])
-
           faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
           Diplomat.configuration.acl_token = valid_acl_token
-
           kv = Diplomat::Kv.new(faraday)
-
           expect(kv.get("key")).to eq("toast")
-
         end
       end
     end
@@ -65,16 +56,12 @@ describe Diplomat::Kv do
     describe "#put" do
       context "ACLs NOT enabled" do
         it "PUT" do
-          # faraday.stub(:put).with(key_url, key_params).and_return(OpenStruct.new({ body: "true\n"}))
           faraday.stub(:put).and_return(OpenStruct.new({ body: "true\n"}))
           kv = Diplomat::Kv.new(faraday)
-
           expect(kv.put(key, key_params)).to eq(key_params)
         end
         it "PUT with CAS param" do
           options = {:cas => modify_index}
-          # url = "#{key_url}?cas=#{modify_index}"
-          # faraday.stub(:put).with(url, key_params).and_return(OpenStruct.new({ body: "true\n"}))
           faraday.stub(:put).and_return(OpenStruct.new({ body: "true\n"}))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params, options)).to eq(key_params)
@@ -82,15 +69,12 @@ describe Diplomat::Kv do
       end
       context "ACLs enabled, without valid_acl_token" do
         it "PUT with ACLs enabled, no valid_acl_token" do
-          faraday.stub(:put).and_return(OpenStruct.new({ body: "false\n" }))
-          
+          faraday.stub(:put).and_return(OpenStruct.new({ body: "false\n" }))    
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params)).to eq("false\n")
         end
         it "PUT with CAS param, without valid_acl_token" do
           options = {:cas => modify_index}
-          # url = "#{key_url}?cas=#{modify_index}"
-          # faraday.stub(:put).with(url, key_params).and_return(OpenStruct.new({ body: "true\n"}))
           faraday.stub(:put).and_return(OpenStruct.new({ body: "false\n"}))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params, options)).to eq("false\n")
@@ -98,8 +82,7 @@ describe Diplomat::Kv do
       end
       context "ACLs enabled, with valid_acl_token" do
         it "PUT with ACLs enabled, valid_acl_token" do
-          faraday.stub(:put).and_return(OpenStruct.new({ body: "true\n"}))
-          
+          faraday.stub(:put).and_return(OpenStruct.new({ body: "true\n"}))        
           Diplomat.configuration.acl_token = valid_acl_token
           kv = Diplomat::Kv.new(faraday)
 
@@ -107,12 +90,35 @@ describe Diplomat::Kv do
         end
         it "PUT with CAS param" do
           options = {:cas => modify_index}
-          # url = "#{key_url}?cas=#{modify_index}"
-          # faraday.stub(:put).with(url, key_params).and_return(OpenStruct.new({ body: "true\n"}))
           faraday.stub(:put).and_return(OpenStruct.new({ body: "true\n"}))
           Diplomat.configuration.acl_token = valid_acl_token
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params, options)).to eq(key_params)
+        end
+      end
+    end
+
+    describe "#delete" do
+      context "ACLs NOT enabled" do
+        it "DELETE" do
+          faraday.stub(:delete).and_return(OpenStruct.new({ status: 200}))
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.delete(key).status).to eq 200 
+        end
+      end
+      context "ACLs enabled, without valid_acl_token" do
+        it "DELETE" do
+          faraday.stub(:delete).and_return(OpenStruct.new({ status: 403}))
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.delete(key).status).to eq 403 
+        end
+      end
+      context "ACLs enabled, with valid_acl_token" do
+        it "DELETE" do
+          faraday.stub(:delete).and_return(OpenStruct.new({ status: 200}))
+          Diplomat.configuration.acl_token = valid_acl_token
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.delete(key).status).to eq 200 
         end
       end
     end

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -115,10 +115,6 @@ describe Diplomat::Kv do
           expect(kv.put(key, key_params, options)).to eq(key_params)
         end
       end
-      context "ACLs NOT enabled" do
-
-        
-      end
     end
 
     it "namespaces" do

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -11,35 +11,114 @@ describe Diplomat::Kv do
     let(:key_url) { "/v1/kv/#{key}" }
     let(:key_params) { "toast" }
     let(:modify_index) { 99 }
+    let(:valid_acl_token) { "f45cbd0b-5022-47ab-8640-4eaa7c1f40f1" }
 
-    it "GET" do
-      json = JSON.generate([{
-        "Key"   => key,
-        "Value" => Base64.encode64(key_params),
-        "Flags" => 0
-      }])
+    describe "#get" do
+      context "ACLs NOT enabled" do
+        it "GET" do
+          json = JSON.generate([{
+            "Key"   => key,
+            "Value" => Base64.encode64(key_params),
+            "Flags" => 0
+          }])
 
-      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+          faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
 
-      kv = Diplomat::Kv.new(faraday)
+          kv = Diplomat::Kv.new(faraday)
 
-      expect(kv.get("key")).to eq("toast")
+          expect(kv.get("key")).to eq("toast")
+        end
+      end    
+      context "ACLs enabled, without valid_acl_token" do
+        it "GET with ACLs enabled, no valid_acl_token" do
+          json = JSON.generate([{
+            "Key"   => key,
+            "Value" => Base64.encode64("Faraday::ResourceNotFound: the server responded with status 404"),
+            "Flags" => 0
+          }])
+
+          faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+          kv = Diplomat::Kv.new(faraday)
+
+          expect(kv.get("key")).to eq("Faraday::ResourceNotFound: the server responded with status 404")
+        end
+      end
+      context "ACLs enabled, with valid_acl_token" do
+        it "GET with ACLs enabled, valid_acl_token" do
+          json = JSON.generate([{
+            "Key"   => key,
+            "Value" => Base64.encode64(key_params),
+            "Flags" => 0
+          }])
+
+          faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+          Diplomat.configuration.acl_token = valid_acl_token
+
+          kv = Diplomat::Kv.new(faraday)
+
+          expect(kv.get("key")).to eq("toast")
+
+        end
+      end
     end
 
-    it "PUT" do
-      faraday.stub(:put).with(key_url, key_params).and_return(OpenStruct.new({ body: "true\n"}))
-      kv = Diplomat::Kv.new(faraday)
+    describe "#put" do
+      context "ACLs NOT enabled" do
+        it "PUT" do
+          # faraday.stub(:put).with(key_url, key_params).and_return(OpenStruct.new({ body: "true\n"}))
+          faraday.stub(:put).and_return(OpenStruct.new({ body: "true\n"}))
+          kv = Diplomat::Kv.new(faraday)
 
-      expect(kv.put(key, key_params)).to eq(key_params)
-    end
+          expect(kv.put(key, key_params)).to eq(key_params)
+        end
+        it "PUT with CAS param" do
+          options = {:cas => modify_index}
+          # url = "#{key_url}?cas=#{modify_index}"
+          # faraday.stub(:put).with(url, key_params).and_return(OpenStruct.new({ body: "true\n"}))
+          faraday.stub(:put).and_return(OpenStruct.new({ body: "true\n"}))
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.put(key, key_params, options)).to eq(key_params)
+        end
+      end
+      context "ACLs enabled, without valid_acl_token" do
+        it "PUT with ACLs enabled, no valid_acl_token" do
+          faraday.stub(:put).and_return(OpenStruct.new({ body: "false\n" }))
+          
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.put(key, key_params)).to eq("false\n")
+        end
+        it "PUT with CAS param, without valid_acl_token" do
+          options = {:cas => modify_index}
+          # url = "#{key_url}?cas=#{modify_index}"
+          # faraday.stub(:put).with(url, key_params).and_return(OpenStruct.new({ body: "true\n"}))
+          faraday.stub(:put).and_return(OpenStruct.new({ body: "false\n"}))
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.put(key, key_params, options)).to eq("false\n")
+        end
+      end
+      context "ACLs enabled, with valid_acl_token" do
+        it "PUT with ACLs enabled, valid_acl_token" do
+          faraday.stub(:put).and_return(OpenStruct.new({ body: "true\n"}))
+          
+          Diplomat.configuration.acl_token = valid_acl_token
+          kv = Diplomat::Kv.new(faraday)
 
-    it "cas PUT" do
-      options = {:cas => modify_index}
-      url = "#{key_url}?cas=#{modify_index}"
-      faraday.stub(:put).with(url, key_params).and_return(OpenStruct.new({ body: "true\n"}))
+          expect(kv.put(key, key_params)).to eq(key_params)
+        end
+        it "PUT with CAS param" do
+          options = {:cas => modify_index}
+          # url = "#{key_url}?cas=#{modify_index}"
+          # faraday.stub(:put).with(url, key_params).and_return(OpenStruct.new({ body: "true\n"}))
+          faraday.stub(:put).and_return(OpenStruct.new({ body: "true\n"}))
+          Diplomat.configuration.acl_token = valid_acl_token
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.put(key, key_params, options)).to eq(key_params)
+        end
+      end
+      context "ACLs NOT enabled" do
 
-      kv = Diplomat::Kv.new(faraday)
-      expect(kv.put(key, key_params, options)).to eq(key_params)
+        
+      end
     end
 
     it "namespaces" do


### PR DESCRIPTION
Added new configuration parameter acl_token.
Set: Diplomat.configuration.acl_token = token
Reworked the #get, #put, #delete methods to be more flexible, for adding more parameters in the future.
Added context for tests, to differentiate them easier.