### PR TITLE
Session and Lock fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ foo_service = Diplomat::Service.get('foo', :all)
 Creating a session:
 
 ```ruby
-sessionid = Diplomat::Session.create({:hostname => "server1", :ipaddress => "4.4.4.4"})
+sessionid = Diplomat::Session.create({:Node => "server1", :Name => "my-lock"})
 # => "fc5ca01a-c317-39ea-05e8-221da00d3a12"
 ```
 Or destroying a session:
@@ -101,7 +101,7 @@ Diplomat::Session.destroy("fc5ca01a-c317-39ea-05e8-221da00d3a12")
 Acquire a lock:
 
 ```ruby
-sessionid = Diplomat::Session.create({:hostname => "server1", :ipaddress => "4.4.4.4"})
+sessionid = Diplomat::Session.create({:Node => "server1", :Name => "my-lock"})
 lock_acquired = Diplomat::Lock.acquire("/key/to/lock", sessionid)
 # => true
 ```

--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -13,9 +13,7 @@ module Diplomat
         req.url "/v1/kv/#{key}?acquire=#{session}"
         req.body = value unless value.nil?
       end
-      return true if raw.body == 'true'
-      return false
-
+      raw.body == 'true'
     end
 
     # wait to aquire a lock

--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -6,10 +6,12 @@ module Diplomat
     # Acquire a lock
     # @param key [String] the key
     # @param session [String] the session, generated from Diplomat::Session.create
+    # @param value [String] the value for the key
     # @return [Boolean] If the lock was acquired
-    def acquire key, session
+    def acquire key, session, value=nil
       raw = @conn.put do |req|
         req.url "/v1/kv/#{key}?acquire=#{session}"
+        req.body = value unless value.nil?
       end
       return true if raw.body == 'true'
       return false
@@ -19,12 +21,13 @@ module Diplomat
     # wait to aquire a lock
     # @param key [String] the key
     # @param session [String] the session, generated from Diplomat::Session.create
+    # @param value [String] the value for the key
     # @param check_interval [Integer] number of seconds to wait between retries
     # @return [Boolean] If the lock was acquired
-    def wait_to_acquire key, session, check_interval=10
+    def wait_to_acquire key, session, value=nil, check_interval=10
       acquired = false
       while !acquired
-        acquired = self.acquire key, session
+        acquired = self.acquire key, session, value
         sleep(check_interval) if !acquired
         return true if acquired
       end

--- a/lib/diplomat/session.rb
+++ b/lib/diplomat/session.rb
@@ -6,12 +6,12 @@ module Diplomat
     # Create a new session
     # @param value [Object] hash or json representation of the session arguments
     # @return [String] The sesssion id
-    def create value
+    def create value=nil
       # TODO: only certain keys are recognised in a session create request,
       # should raise an error on others.
       raw = @conn.put do |req|
         req.url "/v1/session/create"
-        req.body = if value.kind_of?(String) then value else JSON.generate(value) end
+        req.body = (if value.kind_of?(String) then value else JSON.generate(value) end) unless value.nil?
       end
       body = JSON.parse(raw.body)
       return body["ID"]

--- a/lib/diplomat/session.rb
+++ b/lib/diplomat/session.rb
@@ -4,12 +4,14 @@ module Diplomat
   class Session < Diplomat::RestClient
 
     # Create a new session
-    # @param value [String] json representation of the local node
+    # @param value [Object] hash or json representation of the session arguments
     # @return [String] The sesssion id
     def create value
+      # TODO: only certain keys are recognised in a session create request,
+      # should raise an error on others.
       raw = @conn.put do |req|
         req.url "/v1/session/create"
-        req.body = value
+        req.body = if value.kind_of?(String) then value else JSON.generate(value) end
       end
       body = JSON.parse(raw.body)
       return body["ID"]


### PR DESCRIPTION
Various fixed to the Session and Lock code:
- README.md says Session.create can take a hash, and indeed it can, but it's rendered to a URL-encoded body by the current code. Change to render to JSON.
- Session create request bodies should only specify certain keys (which override defaults). README.md listed arbitrary keys, possibly confusing the Session and Lock objects? Fixed to use valid keys.
- Session create request bodies are optional; each value has a sane default.
- Acquiring a lock is actually the act of writing a value to a key, so the value should be able to be specified (the consul docs recommend using this value to record something about the lock holder).