### PR TITLE
[WIP] Fix/return nil on 404

### DIFF
--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -17,7 +17,7 @@ module Diplomat
         @raw = @conn.get concat_url url
         parse_body
       rescue Faraday::ResourceNotFound
-        @raw = { 'Value' => nil }
+        @raw = [{ 'Value' => nil }]
       end
       return_value
     end

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -9,7 +9,7 @@ module Diplomat
     # Get a value by its key
     # @param key [String] the key
     # @return [String] The base64-decoded value associated with the key
-    def get key
+    def get key, default_value = nil
       @key = key
       url = ["/v1/kv/#{@key}"]
       url += check_acl_token unless check_acl_token.nil?
@@ -17,7 +17,8 @@ module Diplomat
         @raw = @conn.get concat_url url
         parse_body
       rescue Faraday::ResourceNotFound
-        @raw = [{ 'Value' => nil }]
+        default_value = Base64.encode64(default_value) unless default_value.nil?
+        @raw = [{ 'Value' => default_value }]
       end
       return_value
     end

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -13,8 +13,12 @@ module Diplomat
       @key = key
       url = ["/v1/kv/#{@key}"]
       url += check_acl_token unless check_acl_token.nil?
-      @raw = @conn.get concat_url url
-      parse_body
+      begin
+        @raw = @conn.get concat_url url
+        parse_body
+      rescue Faraday::ResourceNotFound
+        @raw = { 'Value' => nil }
+      end
       return_value
     end
 

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -49,6 +49,11 @@ describe Diplomat::Kv do
             kv = Diplomat::Kv.new(faraday)
             expect(kv.get("key")).to eq(nil)
           end
+
+          it "GET with a default" do
+            kv = Diplomat::Kv.new(faraday)
+            expect(kv.get('key', 'bob')).to eq('bob')
+          end
         end
       end
 

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -64,6 +64,7 @@ describe Diplomat::Kv do
           expect(kv.get("key")).to eq("Faraday::ResourceNotFound: the server responded with status 404")
         end
       end
+
       context "ACLs enabled, with valid_acl_token" do
         it "GET with ACLs enabled, valid_acl_token" do
           json = JSON.generate([{
@@ -133,14 +134,14 @@ describe Diplomat::Kv do
         it "DELETE" do
           faraday.stub(:delete).and_return(OpenStruct.new({ status: 200}))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.delete(key).status).to eq 200 
+          expect(kv.delete(key).status).to eq 200
         end
       end
       context "ACLs enabled, without valid_acl_token" do
         it "DELETE" do
           faraday.stub(:delete).and_return(OpenStruct.new({ status: 403}))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.delete(key).status).to eq 403 
+          expect(kv.delete(key).status).to eq 403
         end
       end
       context "ACLs enabled, with valid_acl_token" do


### PR DESCRIPTION
Consul, as a HTTP API key value store handles missing key properly by returning a 404 code.

Faraday itself handles that by raising an exception and it's then down to the application code to do something about it.

Usually key value stores libraries return a nil or empty string value for missing keys. A nil value is more manageable in Ruby.

The patch adds a rescue on the Faraday::ResourceNotFound exception around the @conn.get. This rescue set the @raw attribute to a simple hash with a nil Value.

The return_value method is then still called to use the rest of the chain as usual.

A spec for the get on a missing key has been added with some refactoring. A similar spec can be added in the ACL block too.