### PR TITLE
improve/recurse responses

### DIFF
--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -69,7 +69,7 @@ module Diplomat
 
     # Parse the body, apply it to the raw attribute
     def parse_body
-      @raw = JSON.parse(@raw.body).first
+      @raw = JSON.parse(@raw.body)
     end
 
     # Get the key from the raw output
@@ -79,8 +79,17 @@ module Diplomat
 
     # Get the value from the raw output
     def return_value
-      @value = @raw["Value"]
-      @value = Base64.decode64(@value) unless @value.nil?
+      if @raw.count == 1
+        @value = @raw.first["Value"]
+        @value = Base64.decode64(@value) unless @value.nil?
+      else
+        @value = @raw.map do |e|
+                   {
+                     key: e["Key"],
+                     value: e["Value"].nil? ? e["Value"] : Base64.decode64(e["Value"])
+                   }
+                 end
+      end
     end
 
     def check_acl_token

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -14,6 +14,28 @@ describe Diplomat::Kv do
     let(:valid_acl_token) { "f45cbd0b-5022-47ab-8640-4eaa7c1f40f1" }
 
     describe "#get" do
+      context "ACLs NOT enabled, recurse option ON" do
+        it "GET" do
+          json = JSON.generate([
+            {
+              "Key"   => key + 'dewfr',
+              "Value" => Base64.encode64(key_params),
+              "Flags" => 0
+            },
+            {
+              "Key"   => key,
+              "Value" => Base64.encode64(key_params),
+              "Flags" => 0
+            }])
+          faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.get("key?recurse")).to eql([
+                                             { key: 'keydewfr', value: "toast" },
+                                             { key: 'key', value: "toast" }
+                                           ])
+        end
+      end
+
       context "ACLs NOT enabled" do
         it "GET" do
           json = JSON.generate([{


### PR DESCRIPTION
Consul kv/ can handle a recurse option on the GET v1/kv/:key endpoint.
In that case Consul returns an array of entries matching the key.

It's an handy way to namespace or group keys based on a prefix of sorts.

As it is Diplomat would only returns one entry in the response even if the recurse option is passed with the key.

This patch allows Diplomat to return an Array of {key, value} entries that were returned by consul if there is more than 1 entry in the response.

As this will not happen if the ?recurse option is not passed in the key (Diplomat.kv.get("some?recurse")) I would consider it a non breaking change but an extension of the current behaviour.

Another solution would be to add a get_recurse method reusing the same principle added in the return_value method.

See added spec for behaviour too.