### PR TITLE
Use ruby 1.8 syntax in production code.

### DIFF
--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -140,8 +140,8 @@ module Diplomat
       else
         @value = @raw.map do |e|
                    {
-                     key: e["Key"],
-                     value: e["Value"].nil? ? e["Value"] : Base64.decode64(e["Value"])
+                     :key => e["Key"],
+                     :value => e["Value"].nil? ? e["Value"] : Base64.decode64(e["Value"])
                    }
                  end
       end


### PR DESCRIPTION
I know Ruby 1.8 is old, but I still have to use it, and currently all of the code in lib/ works on 1.8, with the exception of these two lines, recently added in a5056ea. I'd like to keep on top of the 1.8 compatibility while it's still easy. There really isn't a great loss here, it's only hash syntax, not a massive increase in verbosity or a loss in functionality.

I've left the tests alone - they contain quite a lot of newer ruby syntax, and have done for a while.