### PR TITLE
Add a dc option to the service interface

### DIFF
--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'faraday'
+require 'pry'
 
 module Diplomat
   class Service < Diplomat::RestClient
@@ -22,6 +23,11 @@ module Diplomat
         qs = "#{qs}#{sep}index=#{options[:index]}"
         sep = "&"
       end
+      if options and options[:dc]
+        qs = "#{qs}#{sep}dc=#{options[:dc]}"
+        sep = "&"
+      end
+
 
       ret = @conn.get "/v1/catalog/service/#{key}#{qs}"
 
@@ -39,7 +45,7 @@ module Diplomat
 
     # @note This is sugar, see (#get)
     def self.get *args
-      Diplomat::Service.new.get *args
+      new(*args).get
     end
 
   end

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -1,6 +1,5 @@
 require 'base64'
 require 'faraday'
-require 'pry'
 
 module Diplomat
   class Service < Diplomat::RestClient

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -9,9 +9,10 @@ describe Diplomat::Service do
   context "services" do
     let(:key) { "toast" }
     let(:key_url) { "/v1/catalog/service/#{key}" }
-    let(:key_url_with_alloptions) { "/v1/catalog/service/#{key}?wait=5m&index=3" }
+    let(:key_url_with_alloptions) { "/v1/catalog/service/#{key}?wait=5m&index=3&dc=somedc" }
     let(:key_url_with_indexoption) { "/v1/catalog/service/#{key}?index=5" }
     let(:key_url_with_waitoption) { "/v1/catalog/service/#{key}?wait=6s" }
+    let(:key_url_with_datacenteroption) { "/v1/catalog/service/#{key}?dc=somedc" }
     let(:body) {
       [
         {
@@ -116,14 +117,26 @@ describe Diplomat::Service do
         expect(s.Node).to eq("foo")
       end
 
-      it "both options" do
+      it "datacenter option" do
+        json = JSON.generate(body)
+
+        faraday.stub(:get).with(key_url_with_datacenteroption).and_return(OpenStruct.new({ body: json, headers: headers }))
+
+        service = Diplomat::Service.new(faraday)
+
+        options = { :dc => "somedc" }
+        s = service.get("toast", :first, options)
+        expect(s.Node).to eq("foo")
+      end
+
+      it "all options" do
         json = JSON.generate(body)
 
         faraday.stub(:get).with(key_url_with_alloptions).and_return(OpenStruct.new({ body: json, headers: headers }))
 
         service = Diplomat::Service.new(faraday)
 
-        options = { :wait => "5m", :index => "3" }
+        options = { :wait => "5m", :index => "3", :dc => 'somedc' }
         s = service.get("toast", :first, options)
         expect(s.Node).to eq("foo")
       end


### PR DESCRIPTION
Howdy,

I'm working on integrating diplomat in our org, and one thing that I can see as being super helpful in the near-to-mid term is the ability to query on a service per datacenter. I've added the support based on the [query string documented in the consul docs](https://consul.io/docs/agent/http/catalog.html#catalog_service).

It's just piggy-backing on the basic pattern you already have in place for adding query strings from the options hash. Specs covering the additionally query string are also implemented. I didn't add any specs covering the cases where there are 2 of 3 options present, but I'm happy to do so if you'd like.