### PR TITLE
Add option to return default value rather than throw when keys, events aren't found

### DIFF
--- a/lib/diplomat/event.rb
+++ b/lib/diplomat/event.rb
@@ -25,7 +25,7 @@ module Diplomat
     # Get the list of events matching name
     # @param name [String] the name of the event (regex)
     # @param not_found [Symbol] behaviour if there are no events matching name;
-    #   :reject with exception, or :wait for a non-empty list
+    #   :reject with exception, :return degenerate value, or :wait for a non-empty list
     # @param found [Symbol] behaviour if there are already events matching name;
     #   :reject with exception, :return its current value, or :wait for its next value
     # @return [Array[hash]] The list of { :name, :payload } hashes
@@ -45,6 +45,9 @@ module Diplomat
     #   - X X - meaningless; never return a value
     #   - X R - "normal" non-blocking get operation. Default
     #   - X W - get the next value only (must have a current value)
+    #   - R X - meaningless; never return a meaningful value
+    #   - R R - "safe" non-blocking, non-throwing get-or-default operation
+    #   - R W - get the next value or a default
     #   - W X - get the first value only (must not have a current value)
     #   - W R - get the first or current value; always return something, but
     #           block only when necessary
@@ -59,6 +62,8 @@ module Diplomat
         case not_found
           when :reject
             raise Diplomat::EventNotFound, name
+          when :return
+            return []
           when :wait
             index = @raw.headers["x-consul-index"]
         end
@@ -90,7 +95,7 @@ module Diplomat
     #   String are tokens returned by previous calls to this function
     #   Symbols are the special tokens :first, :last, and :next
     # @param not_found [Symbol] behaviour if there is no matching event;
-    #   :reject with exception, or :wait for event
+    #   :reject with exception, :return degenerate value, or :wait for event
     # @param found [Symbol] behaviour if there is a matching event;
     #   :reject with exception, or :return its current value
     # @return [hash] A hash with keys :value and :token;
@@ -120,6 +125,10 @@ module Diplomat
         case not_found
           when :reject
             raise Diplomat::EventNotFound, name
+          when :return
+            event_name = ""
+            event_payload = ""
+            event_token = :last
           when :wait
             # Wait for next event
             index = @raw.headers["x-consul-index"]
@@ -130,6 +139,9 @@ module Diplomat
             end
             body = JSON.parse(@raw.body)
             event = body.last # If it's possible for two events to arrive at once, this needs to #find again
+            event_name = event["Name"]
+            event_payload = Base64.decode64(event["Payload"])
+            event_token = event["ID"]
         end
       else
         case found
@@ -137,11 +149,14 @@ module Diplomat
             raise Diplomat::EventAlreadyExits, name
           when :return
             event = body[idx]
+            event_name = event["Name"]
+            event_payload = Base64.decode64(event["Payload"])
+            event_token = event["ID"]
         end
       end
 
-      { :value => { :name => event["Name"], :payload => Base64.decode64(event["Payload"]) },
-        :token => event["ID"] }
+      { :value => { :name => event_name, :payload => event_payload },
+        :token => event_token }
     end
 
 

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -11,7 +11,7 @@ module Diplomat
     # @param options [Hash] the query params
     # @option options [String] :consistency The read consistency type
     # @param not_found [Symbol] behaviour if the key doesn't exist;
-    #   :reject with exception, or :wait for it to appear
+    #   :reject with exception, :return degenerate value, or :wait for it to appear
     # @param found [Symbol] behaviour if the key does exist;
     #   :reject with exception, :return its current value, or :wait for its next value
     # @return [String] The base64-decoded value associated with the key
@@ -24,6 +24,9 @@ module Diplomat
     #   - X X - meaningless; never return a value
     #   - X R - "normal" non-blocking get operation. Default
     #   - X W - get the next value only (must have a current value)
+    #   - R X - meaningless; never return a meaningful value
+    #   - R R - "safe" non-blocking, non-throwing get-or-default operation
+    #   - R W - get the next value or a default
     #   - W X - get the first value only (must not have a current value)
     #   - W R - get the first or current value; always return something, but
     #           block only when necessary
@@ -42,6 +45,8 @@ module Diplomat
         case not_found
           when :reject
             raise Diplomat::KeyNotFound, key
+          when :return
+            return @value = ""
           when :wait
             index = raw.headers["x-consul-index"]
         end


### PR DESCRIPTION
This is very similar to PR#22, which I notice was never finished and is now out of date, as it's based on the code prior to me adding all the extra arguments and code to Kv#get.

This patch maintains the default behavior of Kv|Event#get, but allows the user to request a "null" value rather than an exception, using the existing not_found parameter. It also makes that parameter more similar to the found parameter, simplifying the API.

The default value can't be specified, I think that's a step too far, but I think the values are sensible. I've got the for identity element of the type String and Array - "" and [], rather than nil. This is because they're nulipotent in most operations like + and <<, whereas nil is often used to signal an error and propagates. If the user considers the missing key or empty event stream an error, they should specify not_found=:reject which will raise an actual error.