### PR TITLE
Add optional configuration options for Faraday

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Diplomat.configure do |config|
   config.middleware = MyCustomMiddleware
   # Connect into consul with custom access token (ACL)
   config.acl_token =  "xxxxxxxx-yyyy-zzzz-1111-222222222222"
+  # Set extra Faraday configuration options
+  config.options = {ssl: { version: :TLSv1_2 }}
 end
 ```
 
@@ -194,7 +196,7 @@ This is traditionally kept inside the `config/initializers` directory if you're 
 -  [ ] Updating Docs with latest changes
 -  [ ] Using custom objects for response objects (instead of openStruct)
 -  [ ] PUTing and DELETEing services
--  [ ] Custom SSL Cert Middleware for faraday
+-  [x] Custom SSL Cert Middleware for faraday
 -  [x] Allowing the custom configuration of the consul url to connect to
 -  [x] Deleting Keys
 -  [x] Listing available services

--- a/lib/diplomat/configuration.rb
+++ b/lib/diplomat/configuration.rb
@@ -1,15 +1,17 @@
 module Diplomat
   class Configuration
     attr_accessor :middleware
-    attr_accessor :url, :acl_token
+    attr_accessor :url, :acl_token, :options
 
     # Override defaults for configuration
     # @param url [String] consul's connection URL
     # @param acl_token [String] a connection token used when making requests to consul
-    def initialize(url="http://localhost:8500", acl_token=nil)
+    # @param options [Hash] extra options to configure Faraday::Connection
+    def initialize(url="http://localhost:8500", acl_token=nil, options = {})
       @middleware = []
       @url = url
       @acl_token = acl_token
+      @options = options
     end
 
     # Define a middleware for Faraday

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -58,7 +58,7 @@ module Diplomat
     end
 
     def build_connection(api_connection, raise_error=false)
-      return api_connection || Faraday.new(:url => Diplomat.configuration.url) do |faraday|
+      return api_connection || Faraday.new(Diplomat.configuration.url, Diplomat.configuration.options) do |faraday|
         faraday.adapter  Faraday.default_adapter
         faraday.request  :url_encoded
         faraday.response :raise_error unless raise_error

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -29,6 +29,11 @@ describe Diplomat do
         expect(config.middleware).to be_a(Array)
         expect(config.middleware.length).to eq(0)
       end
+
+      it "Returns an empty options hash" do
+        expect(config.options).to be_a(Hash)
+        expect(config.options).to be_empty
+      end
     end
 
     context "Custom Configuration" do
@@ -48,12 +53,14 @@ describe Diplomat do
           config.url = "http://google.com"
           config.acl_token = "f45cbd0b-5022-47ab-8640-4eaa7c1f40f1"
           config.middleware = StubMiddleware
+          config.options = {ssl: { verify: true }}
         end
 
         expect(Diplomat.configuration.url).to eq("http://google.com")
         expect(Diplomat.configuration.acl_token).to eq("f45cbd0b-5022-47ab-8640-4eaa7c1f40f1")
         expect(Diplomat.configuration.middleware).to be_a(Array)
         expect(Diplomat.configuration.middleware.first).to eq(StubMiddleware)
+        expect(Diplomat.configuration.options).to eq({ssl: { verify: true }})
       end
 
       it "Can set multiple middleware" do


### PR DESCRIPTION
With additional configuration options you can now use client certs like this:

``` ruby
require "openssl"

Diplomat.configure do |config|
  config.url = "https://server.dc1.consul:8501"
  config.options = {ssl: {
    client_cert: OpenSSL::X509::Certificate.new(File.read("client.crt")),
    client_key: OpenSSL::PKey::RSA.new(File.read("client.key")),
    ca_file: "ca.crt",
    verify: true
  }}
end
```

Faraday's options are described [here](https://github.com/lostisland/faraday/blob/c2f325a3298a8c71d0f0b3b93f24d0f0f7409302/lib/faraday.rb#L44), its Net::HTTP specific SSL options are described [here](https://github.com/lostisland/faraday/blob/c2f325a3298a8c71d0f0b3b93f24d0f0f7409302/lib/faraday/adapter/net_http.rb#L98).