### PR TITLE
Added datacenter option to get a list of avaliable datacenters

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ foo_service = Diplomat::Service.get('foo', :all)
 # => [#<OpenStruct Node="hotel", Address="1.2.3.4", ServiceID="hotel_foo", ServiceName="foo", ServiceTags=["foo"], ServicePort=5432>,#<OpenStruct Node="indigo", Address="1.2.3.5", ServiceID="indigo_foo", ServiceName="foo", ServiceTags=["foo"], ServicePort=5432>]
 ```
 
+Or if you want to find services for a particular datacenter
+
+```ruby
+foo_service = Diplomat::Service.get('foo', :all, { :dc => 'My_Datacenter'})
+# => [#<OpenStruct Node="hotel", Address="1.2.3.4", ServiceID="hotel_foo", ServiceName="foo", ServiceTags=["foo"], ServicePort=5432>,#<OpenStruct Node="indigo", Address="1.2.3.5", ServiceID="indigo_foo", ServiceName="foo", ServiceTags=["foo"], ServicePort=5432>]
+```
+
+### Datacenters
+
+Getting a list of datacenters is quite simple and gives you the option to extract all services out of
+all accessible datacenters if you need to.
+
+```ruby
+datacenters = Diplomat::Service.get('foo', :all)
+# => ["DC1", "DC2"]
+```
+
 ### Sessions
 
 Creating a session:

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Getting a list of datacenters is quite simple and gives you the option to extrac
 all accessible datacenters if you need to.
 
 ```ruby
-datacenters = Diplomat::Service.get('foo', :all)
+datacenters = Diplomat::Datacenter.get()
 # => ["DC1", "DC2"]
 ```
 

--- a/lib/diplomat.rb
+++ b/lib/diplomat.rb
@@ -21,7 +21,7 @@ module Diplomat
   self.root_path = File.expand_path "..", __FILE__
   self.lib_path = File.expand_path "../diplomat", __FILE__
 
-  require_libs "configuration", "rest_client", "kv", "service", "members", "check", "health", "session", "lock", "error", "event"
+  require_libs "configuration", "rest_client", "kv", "datacenter", "service", "members", "check", "health", "session", "lock", "error", "event"
   self.configuration ||= Diplomat::Configuration.new
 
   class << self

--- a/lib/diplomat/datacenter.rb
+++ b/lib/diplomat/datacenter.rb
@@ -1,0 +1,27 @@
+require 'base64'
+require 'faraday'
+
+module Diplomat
+  class Datacenter < Diplomat::RestClient
+
+    @access_methods = [ :get ]
+
+    # Get an array of all avaliable datacenters accessible by the local consul agent
+    # @param meta [Hash] output structure containing header information about the request (index)
+    # @return [OpenStruct] all datacenters avaliable to this consul agent
+    def get meta=nil
+
+      url = ["/v1/catalog/datacenters"]
+
+      ret = @conn.get concat_url url
+
+      if meta and ret.headers
+        meta[:index] = ret.headers["x-consul-index"]
+        meta[:knownleader] = ret.headers["x-consul-knownleader"]
+        meta[:lastcontact] = ret.headers["x-consul-lastcontact"]
+      end
+      return JSON.parse(ret.body)
+    end
+
+  end
+end

--- a/spec/datacenter_spec.rb
+++ b/spec/datacenter_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+require 'json'
+require 'base64'
+
+describe Diplomat::Datacenter do
+
+  let(:faraday) { fake }
+
+  context "datacenters" do
+    let(:key_url) { "/v1/catalog/datacenters" }
+    let(:body) {
+      [ "dc1", "dc2" ]
+    }
+    let(:headers) {
+      {
+        "x-consul-index"        => "8",
+        "x-consul-knownleader"  => "true",
+        "x-consul-lastcontact"  => "0"
+      }
+    }
+
+    describe "GET" do
+      it "returns dcs" do
+        json = JSON.generate(body)
+
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json }))
+
+        datacenters = Diplomat::Datacenter.new(faraday)
+
+        expect(datacenters.get().size).to eq(2)
+        expect(datacenters.get()[0]).to eq("dc1")
+      end
+    end
+
+    describe "GET With headers" do
+      it "empty headers" do
+        json = JSON.generate(body)
+
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json, headers: nil }))
+
+        datacenters = Diplomat::Datacenter.new(faraday)
+
+        meta = {}
+        expect(datacenters.get(meta).size).to eq(2)
+        expect(datacenters.get(meta)[0]).to eq("dc1")
+        expect(meta.length).to eq(0)
+      end
+
+      it "filled headers" do
+        json = JSON.generate(body)
+
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json, headers: headers }))
+
+        datacenters = Diplomat::Datacenter.new(faraday)
+
+        meta = {}
+        s = datacenters.get(meta)
+        expect(s[0]).to eq("dc1")
+        expect(meta[:index]).to eq("8")
+        expect(meta[:knownleader]).to eq("true")
+        expect(meta[:lastcontact]).to eq("0")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Example Usage:

```
Diplomat::Datacenter.get.each { |dc|
  Diplomat::Service.get('redis', :all, { :dc => dc }).each { |service|
    puts "   server %s %s:$s  check inter 1000 weight 100 " % [service.Node, service.Address, service.ServicePort]
  }
}
```