### PR TITLE
Reject nil values.

### DIFF
--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -80,11 +80,12 @@ module Diplomat
         @value = @raw.first["Value"]
         @value = Base64.decode64(@value) unless @value.nil?
       else
-        @value = @raw.map do |e|
-          {
+        @value = @raw.reduce([]) do |acc, e|
+          acc << {
             :key => e["Key"],
-            :value => (Base64.decode64(e["Value"]) unless e["Value"].nil?)
-          }
+            :value => Base64.decode64(e["Value"])
+          } unless e["Value"].nil?
+          acc
         end
       end
     end

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -26,6 +26,11 @@ describe Diplomat::Kv do
               "Key"   => key,
               "Value" => Base64.encode64(key_params),
               "Flags" => 0
+            },
+            {
+              "Key"   => key + 'iamnil',
+              "Value" => nil,
+              "Flags" => 0
             }])
           faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
           kv = Diplomat::Kv.new(faraday)


### PR DESCRIPTION
If we create a blank folder on the consul ui, and add keys later, and try to fetch it using ```?recurse```, the returned array contains a key ```folder_name/``` whose value is nil.

Checking for nil inside map doesn't work here as the hash is still returned with value ```nil```. Only base64 decoding is avoided for nil values.

![Like so](https://s3.amazonaws.com/f.cl.ly/items/0X3Q302J1p0u44203V1D/diplomat.gif)