### PR TITLE
Add adapter to configuration

### DIFF
--- a/lib/diplomat/configuration.rb
+++ b/lib/diplomat/configuration.rb
@@ -1,6 +1,6 @@
 module Diplomat
   class Configuration
-    attr_accessor :middleware
+    attr_accessor :middleware, :adapter
     attr_accessor :url, :acl_token, :options
 
     # Override defaults for configuration
@@ -12,6 +12,7 @@ module Diplomat
       @url = url
       @acl_token = acl_token
       @options = options
+      @adapter = nil
     end
 
     # Define a middleware for Faraday

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -59,7 +59,7 @@ module Diplomat
 
     def build_connection(api_connection, raise_error=false)
       return api_connection || Faraday.new(Diplomat.configuration.url, Diplomat.configuration.options) do |faraday|
-        faraday.adapter  Faraday.default_adapter
+        faraday.adapter  Diplomat.configuration.adapter || Faraday.default_adapter
         faraday.request  :url_encoded
         faraday.response :raise_error unless raise_error
 

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -16,7 +16,7 @@ describe Diplomat do
     context "Default" do
       let(:config) { Diplomat.configuration }
 
-      it "Returns a Diplmant::Configuration" do
+      it "Returns a Diplomat::Configuration" do
         expect(config).to be_a Diplomat::Configuration
       end
 
@@ -29,6 +29,10 @@ describe Diplomat do
         expect(config.middleware).to be_a(Array)
         expect(config.middleware.length).to eq(0)
       end
+
+      it "Returns no default adapter" do
+        expect(Diplomat.configuration.adapter).to be_nil
+      end 
 
       it "Returns an empty options hash" do
         expect(config.options).to be_a(Hash)
@@ -54,6 +58,7 @@ describe Diplomat do
           config.acl_token = "f45cbd0b-5022-47ab-8640-4eaa7c1f40f1"
           config.middleware = StubMiddleware
           config.options = {ssl: { verify: true }}
+          config.adapter = Faraday::Adapter::NetHttpPersistent
         end
 
         expect(Diplomat.configuration.url).to eq("http://google.com")
@@ -71,6 +76,15 @@ describe Diplomat do
         expect(Diplomat.configuration.middleware).to be_a(Array)
         expect(Diplomat.configuration.middleware.length).to eq(3)
         expect(Diplomat.configuration.middleware.first).to eq(StubMiddleware)
+      end
+
+      it "Can set adapter" do
+        Diplomat.configure do |config|
+          config.adapter = :net_http_persistent
+        end
+
+        expect(Diplomat.configuration.adapter).to be_a(Symbol)
+        expect(Diplomat.configuration.adapter).to eq(:net_http_persistent)
       end
     end
   end


### PR DESCRIPTION
Did I do this right? :)

Some of my Consul servers require client SSL certs and the default Faraday adapter doesn't support them.