### PR TITLE
trim trailing slash of path

### DIFF
--- a/lib/diplomat/session.rb
+++ b/lib/diplomat/session.rb
@@ -33,7 +33,7 @@ module Diplomat
     # @return [Struct]
     def list
       raw = @conn.get do |req|
-        req.url "/v1/session/list/"
+        req.url "/v1/session/list"
       end
       JSON.parse(raw.body)
     end


### PR DESCRIPTION
`Diplomat::Session.list` failed as follows:
```ruby
session_id = Diplomat::Session.create({Name: 'foo'})
Diplomat::Session.list
=> Faraday::ResourceNotFound: the server responded with status 404
```

accoding to api document, endpoing of Lists all active sessions is
`/v1/session/list`, not `/v1/session/list/`.
see : https://www.consul.io/docs/agent/http/session.html#session_list