### PR TITLE
Changed Kv.get to always return an array for recursive calls.

### DIFF
--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -75,8 +75,16 @@ module Diplomat
     end
 
     # Get the key/value(s) from the raw output
-    def return_value
-      if @raw.count == 1
+    #
+    #
+    #
+    # @param [bool] is_recurse, true if we're handling the result of a recursive search
+    # @returns [String|Array] a string equal to the value if it was a regular get and there is
+    #                         a result, otherwise, an array of hashes, where the hash contains
+    #                         :key & :value entries. When nothing was found, either for a recursive
+    #                         search or for a regular one, we return an empty array
+    def return_value is_recurse
+      if @raw.count == 1 && !is_recurse
         @value = @raw.first["Value"]
         @value = Base64.decode64(@value) unless @value.nil?
       else

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -50,6 +50,18 @@ describe Diplomat::Kv do
             { key: 'key', value: "toast" }
           ])
         end
+
+        it "Recursive GET with one response should return an array" do
+          json = JSON.generate([
+                                   {
+                                       "Key"   => key + 'dewfr',
+                                       "Value" => Base64.encode64(key_params),
+                                       "Flags" => 0
+                                   }])
+          faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.get("key", {:recurse=>true})).to eql([{ key: 'keydewfr', value: "toast" }])
+        end
       end
 
       context "ACLs NOT enabled" do


### PR DESCRIPTION
When executing a recursive Kv.get, and there is only one item to
return, Diplomat was returning a string instead of an array of
key/value pairs. This means the caller has no idea what the key
is for the value returned.

To fix the problem, we've added a call to RestClient.return_value
that indicates that it whether this is a recurse get.

I added a spec to test the above behavoir.

One worrisome behavoir remains: if you call Kv.get() with :return
and there is no response, I'm not sure what is the proper response.
For recursive searches, I pretty sure we're still just returning an
empty string. And I think that recursive searches should always
return an array.