### PR TITLE
Get all services

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ foo_service = Diplomat::Service.get('foo', :all, { :dc => 'My_Datacenter'})
 # => [#<OpenStruct Node="hotel", Address="1.2.3.4", ServiceID="hotel_foo", ServiceName="foo", ServiceTags=["foo"], ServicePort=5432>,#<OpenStruct Node="indigo", Address="1.2.3.5", ServiceID="indigo_foo", ServiceName="foo", ServiceTags=["foo"], ServicePort=5432>]
 ```
 
+If you wish to list all the services on consul:
+
+```ruby
+services = Diplomat::Service.get_all
+# => #<OpenStruct consul=[], foo=[], bar=[]>
+```
+
 ### Datacenters
 
 Getting a list of datacenters is quite simple and gives you the option to extract all services out of

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -4,7 +4,7 @@ require 'faraday'
 module Diplomat
   class Service < Diplomat::RestClient
 
-    @access_methods = [ :get, :register, :deregister ]
+    @access_methods = [ :get, :get_all, :register, :deregister ]
 
     # Get a service by it's key
     # @param key [String] the key
@@ -39,6 +39,18 @@ module Diplomat
       end
 
       return OpenStruct.new JSON.parse(ret.body).first
+    end
+
+    # Get all the services
+    def get_all
+      url = "/v1/catalog/services"
+      begin
+        ret = @conn.get url
+      rescue Faraday::ClientError
+        raise Diplomat::PathNotFound
+      end
+
+      return OpenStruct.new JSON.parse(ret.body)
     end
 
     # Register a service

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -42,6 +42,7 @@ module Diplomat
     end
 
     # Get all the services
+    # @return [OpenStruct] the list of all services
     def get_all
       url = "/v1/catalog/services"
       begin

--- a/lib/diplomat/version.rb
+++ b/lib/diplomat/version.rb
@@ -1,3 +1,3 @@
 module Diplomat
-  VERSION = "0.13.2"
+  VERSION = "0.13.3"
 end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -181,8 +181,9 @@ describe Diplomat::Service do
         faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
 
         service = Diplomat::Service.new(faraday)
-        expect(service.get_all.to_h.keys.size).to eq(2)
-        expect(service.get_all.service1.size).to eq(3)
+        expect(service.get_all.service1).to be_an(Array)
+        expect(service.get_all.service2).to be_an(Array)
+        expect(service.get_all.service1.first).to eq("tag one")
         expect(service.get_all.service2.first).to eq("tag four")
       end
     end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -34,6 +34,12 @@ describe Diplomat::Service do
         }
       ]
     }
+    let(:body_all) {
+      {
+        service1: ["tag one", "tag two", "tag three"],
+        service2: ["tag four"]
+      }
+    }
     let(:headers) {
       {
         "x-consul-index"        => "8",
@@ -165,6 +171,19 @@ describe Diplomat::Service do
         options = { :wait => "5m", :index => "3", :dc => 'somedc' }
         s = service.get("toast", :first, options)
         expect(s.Node).to eq("foo")
+      end
+    end
+
+    describe "GET ALL" do
+      it "lists all the services" do
+        json = JSON.generate(body_all)
+
+        faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+
+        service = Diplomat::Service.new(faraday)
+        expect(service.get_all.to_h.keys.size).to eq(2)
+        expect(service.get_all.service1.size).to eq(3)
+        expect(service.get_all.service2.first).to eq("tag four")
       end
     end
 


### PR DESCRIPTION
Adding a method to list all the services.
This might be useful in case you want to know what services are registered without having to query consul for all of them.