### PR TITLE
option to return keys/dirs with null values

### DIFF
--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -44,7 +44,7 @@ module Diplomat
       url += use_consistency(@options)
       url += dc(@options)
 
-      return_nil_values = @options and @options[:nil_values]
+      return_nil_values = (@options and @options[:nil_values])
 
       # 404s OK using this connection
       raw = @conn_no_err.get concat_url url

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -75,16 +75,17 @@ module Diplomat
     end
 
     # Get the key/value(s) from the raw output
-    def return_value
+    def return_value(nil_values=false)
       if @raw.count == 1
         @value = @raw.first["Value"]
         @value = Base64.decode64(@value) unless @value.nil?
       else
         @value = @raw.reduce([]) do |acc, e|
+          val = e["Value"].nil? ? nil : Base64.decode64(e["Value"])
           acc << {
             :key => e["Key"],
-            :value => Base64.decode64(e["Value"])
-          } unless e["Value"].nil?
+            :value => val
+          } if val or nil_values
           acc
         end
       end

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -26,32 +26,42 @@ describe Diplomat::Kv do
       end
 
       context "ACLs NOT enabled, recurse option ON" do
+        let(:json) { JSON.generate([
+          {
+            "Key"   => key + 'dewfr',
+            "Value" => Base64.encode64(key_params),
+            "Flags" => 0
+          },
+          {
+            "Key"   => key,
+            "Value" => Base64.encode64(key_params),
+            "Flags" => 0
+          },
+          {
+            "Key"   => key + 'iamnil',
+            "Value" => nil,
+            "Flags" => 0
+          }])
+        }
+
         it "GET" do
-          json = JSON.generate([
-            {
-              "Key"   => key + 'dewfr',
-              "Value" => Base64.encode64(key_params),
-              "Flags" => 0
-            },
-            {
-              "Key"   => key,
-              "Value" => Base64.encode64(key_params),
-              "Flags" => 0
-            },
-            {
-              "Key"   => key + 'iamnil',
-              "Value" => nil,
-              "Flags" => 0
-            }])
           faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key?recurse")).to eql([
-            { key: 'keydewfr', value: "toast" },
-            { key: 'key', value: "toast" }
+          expect(kv.get(key, recurse: true)).to eql([
+            { key: key + 'dewfr', value: "toast" },
+            { key: key, value: "toast" }
+          ])
+        end
+        it "GET with nil values" do
+          faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.get(key, recurse: true, nil_values: true )).to eql([
+            { key: key + 'dewfr', value: "toast" },
+            { key: key, value: "toast" },
+            { key: key + 'iamnil', value: nil }
           ])
         end
       end
-
       context "ACLs NOT enabled" do
         it "GET" do
           json = JSON.generate([{


### PR DESCRIPTION
An option to return kv keys (mainly dirs) with null values  is critical in some cases.