### PR TITLE
more Ruby 1.8 support, Rspec 3 syntax

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require "bundler/setup"
+require 'bundler/setup'
 Bundler.setup
 
 require 'rspec/core/rake_task'
@@ -7,12 +7,12 @@ require 'cucumber/rake/task'
 
 RSpec::Core::RakeTask.new(:spec)
 Cucumber::Rake::Task.new(:features) do |t|
-    t.cucumber_opts = "features --format pretty"
+  t.cucumber_opts = 'features --format pretty'
 end
 
-desc "Run a bootstrapped consul server for testing"
+desc 'Run a bootstrapped consul server for testing'
 task :consul do
-  system("consul agent -server -bootstrap -data-dir=/tmp")
+  system('consul agent -server -bootstrap -data-dir=/tmp')
 end
 
 task :default => :spec

--- a/diplomat.gemspec
+++ b/diplomat.gemspec
@@ -1,24 +1,24 @@
 require './lib/diplomat/version'
 
-Gem::Specification.new "diplomat", Diplomat::VERSION do |spec|
-  spec.authors       = ["John Hamelink"]
-  spec.email         = ["john@johnhamelink.com"]
-  spec.description   = spec.summary = "Diplomat is a simple wrapper for Consul"
-  spec.homepage      = "https://github.com/johnhamelink/diplomat"
-  spec.license       = "BSD"
+Gem::Specification.new 'diplomat', Diplomat::VERSION do |spec|
+  spec.authors       = ['John Hamelink']
+  spec.email         = ['john@johnhamelink.com']
+  spec.description   = spec.summary = 'Diplomat is a simple wrapper for Consul'
+  spec.homepage      = 'https://github.com/johnhamelink/diplomat'
+  spec.license       = 'BSD'
 
-  spec.files         = `git ls-files lib README.md LICENSE features`.split($/)
+  spec.files         = `git ls-files lib README.md LICENSE features`.split($INPUT_RECORD_SEPARATOR)
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 10.3"
-  spec.add_development_dependency "pry", "~> 0.9"
-  spec.add_development_dependency "rspec", "~> 3.2"
-  spec.add_development_dependency "fakes-rspec", "~> 2.1"
-  spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4.0"
-  spec.add_development_dependency "fivemat"
-  spec.add_development_dependency "gem-release", "~> 0.7"
-  spec.add_development_dependency "cucumber", "~> 2.0"
+  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake', '~> 10.3'
+  spec.add_development_dependency 'pry', '~> 0.9'
+  spec.add_development_dependency 'rspec', '~> 3.2'
+  spec.add_development_dependency 'fakes-rspec', '~> 2.1'
+  spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.4.0'
+  spec.add_development_dependency 'fivemat'
+  spec.add_development_dependency 'gem-release', '~> 0.7'
+  spec.add_development_dependency 'cucumber', '~> 2.0'
 
-  spec.add_runtime_dependency "json", "~> 1.8"
-  spec.add_runtime_dependency "faraday", "~> 0.9"
+  spec.add_runtime_dependency 'json', '~> 1.8'
+  spec.add_runtime_dependency 'faraday', '~> 0.9'
 end

--- a/features/step_definitions/setup_diplomat.rb
+++ b/features/step_definitions/setup_diplomat.rb
@@ -1,22 +1,23 @@
 require 'diplomat'
-Given /^I am setting up a default diplomat$/ do
+Given(/^I am setting up a default diplomat$/)do
 end
 
-Given /^I am setting up a custom diplomat$/ do
+Given(/^I am setting up a custom diplomat$/) do
   class StubMiddleware
     def initialize(app, options = {})
       @app = app
       @options = options
     end
+
     def call(env)
       @app.call(env)
     end
   end
 
-  expect {
+  expect do
     Diplomat.configure do |config|
-      config.url = "http://localhost:8500"
+      config.url = 'http://localhost:8500'
       config.middleware = StubMiddleware
     end
-  }.to_not raise_error
+  end.to_not raise_error
 end

--- a/features/step_definitions/test_key_value.rb
+++ b/features/step_definitions/test_key_value.rb
@@ -1,7 +1,7 @@
-Then /^I should be able to get and put keys$/ do
+Then(/^I should be able to get and put keys$/) do
   # High-fructose Corn Syrup
   Diplomat.put('drink', 'Irn Bru')
-  expect(Diplomat.get('drink')).to eq("Irn Bru")
+  expect(Diplomat.get('drink')).to eq('Irn Bru')
 
   # Sugar
   Diplomat::Kv.put('cake', 'Sponge')

--- a/lib/diplomat.rb
+++ b/lib/diplomat.rb
@@ -1,7 +1,5 @@
 module Diplomat
-
   class << self
-
     attr_accessor :root_path
     attr_accessor :lib_path
     attr_accessor :configuration
@@ -15,17 +13,16 @@ module Diplomat
       end
     end
 
-    alias require_lib require_libs
+    alias_method :require_lib, :require_libs
   end
 
-  self.root_path = File.expand_path "..", __FILE__
-  self.lib_path = File.expand_path "../diplomat", __FILE__
+  self.root_path = File.expand_path '..', __FILE__
+  self.lib_path = File.expand_path '../diplomat', __FILE__
 
-  require_libs "configuration", "rest_client", "kv", "datacenter", "service", "members", "check", "health", "session", "lock", "error", "event"
+  require_libs 'configuration', 'rest_client', 'kv', 'datacenter', 'service', 'members', 'check', 'health', 'session', 'lock', 'error', 'event'
   self.configuration ||= Diplomat::Configuration.new
 
   class << self
-
     # Build optional configuration by yielding a block to configure
     # @yield [Diplomat::Configuration]
     def configure

--- a/lib/diplomat/check.rb
+++ b/lib/diplomat/check.rb
@@ -3,15 +3,14 @@ require 'faraday'
 
 module Diplomat
   class Check < Diplomat::RestClient
-
-    @access_methods = [ :checks, :register_script, :register_ttl,
-                        :deregister, :pass, :warn, :fail ]
+    @access_methods = [:checks, :register_script, :register_ttl,
+                       :deregister, :pass, :warn, :fail]
 
     # Get registered checks
     # @return [OpenStruct] all data associated with the service
     def checks
-      ret = @conn.get "/v1/agent/checks"
-      return JSON.parse(ret.body)
+      ret = @conn.get '/v1/agent/checks'
+      JSON.parse(ret.body)
     end
 
     # Register a check
@@ -22,23 +21,21 @@ module Diplomat
     # @param interval [String] frequency (with units) of the check execution
     # @param ttl [String] time (with units) to mark a check down
     # @return [Integer] Status code
-    def register_script check_id, name, notes, script, interval
+    def register_script(check_id, name, notes, script, interval)
       json = JSON.generate(
-      {
-        "ID" => check_id,
-        "Name" => name,
-        "Notes" => notes,
-        "Script" => script,
-        "Interval" => interval
-      }
+        'ID' => check_id,
+        'Name' => name,
+        'Notes' => notes,
+        'Script' => script,
+        'Interval' => interval
       )
 
       ret = @conn.put do |req|
-        req.url "/v1/agent/check/register"
+        req.url '/v1/agent/check/register'
         req.body = json
       end
 
-      return ret.status == 200
+      ret.status == 200
     end
 
     # Register a TTL check
@@ -47,53 +44,50 @@ module Diplomat
     # @param notes [String] notes about the check
     # @param ttl [String] time (with units) to mark a check down
     # @return [Boolean] Success
-    def register_ttl check_id, name, notes, ttl
-      json = JSON.generate({
-        "ID"    => check_id,
-        "Name"  => name,
-        "Notes" => notes,
-        "TTL"   => ttl,
-      })
+    def register_ttl(check_id, name, notes, ttl)
+      json = JSON.generate('ID' => check_id,
+        'Name'  => name,
+        'Notes' => notes,
+        'TTL'   => ttl,)
 
       ret = @conn.put do |req|
-        req.url "/v1/agent/check/register"
+        req.url '/v1/agent/check/register'
         req.body = json
       end
 
-      return ret.status == 200
+      ret.status == 200
     end
 
     # Deregister a check
     # @param check_id [String] the unique id of the check
     # @return [Integer] Status code
-    def deregister check_id
+    def deregister(check_id)
       ret = @conn.get "/v1/agent/check/deregister/#{check_id}"
-      return ret.status == 200
+      ret.status == 200
     end
 
     # Pass a check
     # @param check_id [String] the unique id of the check
     # @return [Integer] Status code
-    def pass check_id
+    def pass(check_id)
       ret = @conn.get "/v1/agent/check/pass/#{check_id}"
-      return ret.status == 200
+      ret.status == 200
     end
 
     # Warn a check
     # @param check_id [String] the unique id of the check
     # @return [Integer] Status code
-    def warn check_id
+    def warn(check_id)
       ret = @conn.get "/v1/agent/check/warn/#{check_id}"
-      return ret.status == 200
+      ret.status == 200
     end
 
     # Warn a check
     # @param check_id [String] the unique id of the check
     # @return [Integer] Status code
-    def fail check_id
+    def fail(check_id)
       ret = @conn.get "/v1/agent/check/fail/#{check_id}"
-      return ret.status == 200
+      ret.status == 200
     end
-
   end
 end

--- a/lib/diplomat/configuration.rb
+++ b/lib/diplomat/configuration.rb
@@ -7,7 +7,7 @@ module Diplomat
     # @param url [String] consul's connection URL
     # @param acl_token [String] a connection token used when making requests to consul
     # @param options [Hash] extra options to configure Faraday::Connection
-    def initialize(url="http://localhost:8500", acl_token=nil, options = {})
+    def initialize(url = 'http://localhost:8500', acl_token = nil, options = {})
       @middleware = []
       @url = url
       @acl_token = acl_token
@@ -20,7 +20,5 @@ module Diplomat
       return @middleware = middleware if middleware.is_a? Array
       @middleware = [middleware]
     end
-
   end
 end
-

--- a/lib/diplomat/datacenter.rb
+++ b/lib/diplomat/datacenter.rb
@@ -3,25 +3,22 @@ require 'faraday'
 
 module Diplomat
   class Datacenter < Diplomat::RestClient
-
-    @access_methods = [ :get ]
+    @access_methods = [:get]
 
     # Get an array of all avaliable datacenters accessible by the local consul agent
     # @param meta [Hash] output structure containing header information about the request (index)
     # @return [OpenStruct] all datacenters avaliable to this consul agent
-    def get meta=nil
-
-      url = ["/v1/catalog/datacenters"]
+    def get(meta = nil)
+      url = ['/v1/catalog/datacenters']
 
       ret = @conn.get concat_url url
 
-      if meta and ret.headers
-        meta[:index] = ret.headers["x-consul-index"]
-        meta[:knownleader] = ret.headers["x-consul-knownleader"]
-        meta[:lastcontact] = ret.headers["x-consul-lastcontact"]
+      if meta && ret.headers
+        meta[:index] = ret.headers['x-consul-index']
+        meta[:knownleader] = ret.headers['x-consul-knownleader']
+        meta[:lastcontact] = ret.headers['x-consul-lastcontact']
       end
-      return JSON.parse(ret.body)
+      JSON.parse(ret.body)
     end
-
   end
 end

--- a/lib/diplomat/health.rb
+++ b/lib/diplomat/health.rb
@@ -3,59 +3,59 @@ require 'faraday'
 
 module Diplomat
   class Health < Diplomat::RestClient
-    @access_methods = [ :node, :checks, :service, :state,
-                        :unknown, :passing, :warning, :critical ]
+    @access_methods = [:node, :checks, :service, :state,
+                       :unknown, :passing, :warning, :critical]
 
     # Get node health
     # @param n [String] the node
     # @return [OpenStruct] all data associated with the node
-    def node n
+    def node(n)
       ret = @conn.get "/v1/health/node/#{n}"
-      return JSON.parse(ret.body)
+      JSON.parse(ret.body)
     end
 
     # Get service checks
     # @param s [String] the service
     # @return [OpenStruct] all data associated with the node
-    def checks s
+    def checks(s)
       ret = @conn.get "/v1/health/checks/#{s}"
-      return JSON.parse(ret.body)
+      JSON.parse(ret.body)
     end
 
     # Get service health
     # @param s [String] the service
     # @return [OpenStruct] all data associated with the node
-    def service s
+    def service(s)
       ret = @conn.get "/v1/health/service/#{s}"
-      return JSON.parse(ret.body)
+      JSON.parse(ret.body)
     end
 
     # Get service health
     # @param s [String] the state ("unknown", "passing", "warning", or "critical")
     # @return [OpenStruct] all data associated with the node
-    def state s
+    def state(s)
       ret = @conn.get "/v1/health/state/#{s}"
-      return JSON.parse(ret.body)
+      JSON.parse(ret.body)
     end
 
     # Convenience method to get services in unknown state
     def unknown
-      state("unknown")
+      state('unknown')
     end
 
     # Convenience method to get services in passing state
     def passing
-      state("passing")
+      state('passing')
     end
 
     # Convenience method to get services in warning state
     def warning
-      state("warning")
+      state('warning')
     end
 
     # Convenience method to get services in critical state
     def critical
-      state("critical")
+      state('critical')
     end
   end
 end

--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -17,7 +17,7 @@ module Diplomat
       raw.body == 'true'
     end
 
-    # wait to aquire a lock
+    # wait to acquire a lock
     # @param key [String] the key
     # @param session [String] the session, generated from Diplomat::Session.create
     # @param value [String] the value for the key

--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -2,15 +2,14 @@ require 'faraday'
 
 module Diplomat
   class Lock < Diplomat::RestClient
-
-    @access_methods = [ :acquire, :wait_to_acquire, :release ]
+    @access_methods = [:acquire, :wait_to_acquire, :release]
 
     # Acquire a lock
     # @param key [String] the key
     # @param session [String] the session, generated from Diplomat::Session.create
     # @param value [String] the value for the key
     # @return [Boolean] If the lock was acquired
-    def acquire key, session, value=nil
+    def acquire(key, session, value = nil)
       raw = @conn.put do |req|
         req.url "/v1/kv/#{key}?acquire=#{session}"
         req.body = value unless value.nil?
@@ -24,25 +23,24 @@ module Diplomat
     # @param value [String] the value for the key
     # @param check_interval [Integer] number of seconds to wait between retries
     # @return [Boolean] If the lock was acquired
-    def wait_to_acquire key, session, value=nil, check_interval=10
+    def wait_to_acquire(key, session, value = nil, check_interval = 10)
       acquired = false
-      while !acquired
-        acquired = self.acquire key, session, value
-        sleep(check_interval) if !acquired
+      until acquired
+        acquired = acquire key, session, value
+        sleep(check_interval) unless acquired
         return true if acquired
       end
     end
-
 
     # Release a lock
     # @param key [String] the key
     # @param session [String] the session, generated from Diplomat::Session.create
     # @return [nil]
-    def release  key, session
+    def release(key, session)
       raw = @conn.put do |req|
         req.url "/v1/kv/#{key}?release=#{session}"
       end
-      return raw.body
+      raw.body
     end
   end
 end

--- a/lib/diplomat/members.rb
+++ b/lib/diplomat/members.rb
@@ -3,13 +3,13 @@ require 'faraday'
 
 module Diplomat
   class Members < Diplomat::RestClient
-    @access_methods = [ :get ]
+    @access_methods = [:get]
 
     # Get all members
     # @return [OpenStruct] all data associated with the service
     def get
-      ret = @conn.get "/v1/agent/members"
-      return JSON.parse(ret.body)
+      ret = @conn.get '/v1/agent/members'
+      JSON.parse(ret.body)
     end
   end
 end

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -3,12 +3,11 @@ require 'json'
 
 module Diplomat
   class RestClient
-
     @access_methods = []
 
     # Initialize the fadaray connection
     # @param api_connection [Faraday::Connection,nil] supply mock API Connection
-    def initialize api_connection=nil
+    def initialize(api_connection = nil)
       start_connection api_connection
     end
 
@@ -17,14 +16,14 @@ module Diplomat
     # @param value [String] the value of the parameter
     # @return [Array] the resultant parameter string inside an array.
     def use_named_parameter(name, value)
-      if value then ["#{name}=#{value}"] else [] end
+      value ? ["#{name}=#{value}"] : []
     end
 
     # Assemble a url from an array of parts.
     # @param parts [Array] the url chunks to be assembled
     # @return [String] the resultant url string
-    def concat_url parts
-      if parts.length > 1 then
+    def concat_url(parts)
+      if parts.length > 1
         parts.first + '?' + parts.drop(1).join('&')
       else
         parts.first
@@ -32,8 +31,7 @@ module Diplomat
     end
 
     class << self
-
-      def access_method? meth_id
+      def access_method?(meth_id)
         @access_methods.include? meth_id
       end
 
@@ -45,20 +43,19 @@ module Diplomat
       def method_missing(meth_id, *args)
         access_method?(meth_id) ? new.send(meth_id, *args) : super
       end
-
     end
 
     private
 
     # Build the API Client
     # @param api_connection [Faraday::Connection,nil] supply mock API Connection
-    def start_connection api_connection=nil
+    def start_connection(api_connection = nil)
       @conn = build_connection(api_connection)
       @conn_no_err = build_connection(api_connection, true)
     end
 
-    def build_connection(api_connection, raise_error=false)
-      return api_connection || Faraday.new(Diplomat.configuration.url, Diplomat.configuration.options) do |faraday|
+    def build_connection(api_connection, raise_error = false)
+      api_connection || Faraday.new(Diplomat.configuration.url, Diplomat.configuration.options) do |faraday|
         faraday.adapter  Faraday.default_adapter
         faraday.request  :url_encoded
         faraday.response :raise_error unless raise_error
@@ -77,15 +74,14 @@ module Diplomat
     # Get the key/value(s) from the raw output
     def return_value
       if @raw.count == 1
-        @value = @raw.first["Value"]
+        @value = @raw.first['Value']
         @value = Base64.decode64(@value) unless @value.nil?
       else
-        @value = @raw.reduce([]) do |acc, e|
+        @value = @raw.each_with_object([]) do |e, acc|
           acc << {
-            :key => e["Key"],
-            :value => Base64.decode64(e["Value"])
-          } unless e["Value"].nil?
-          acc
+            :key => e['Key'],
+            :value => Base64.decode64(e['Value'])
+          } unless e['Value'].nil?
         end
       end
     end
@@ -93,10 +89,9 @@ module Diplomat
     # Get the name and payload(s) from the raw output
     def return_payload
       @value = @raw.map do |e|
-        { :name => e["Name"],
-          :payload => (Base64.decode64(e["Payload"]) unless e["Payload"].nil?) }
+        { :name => e['Name'],
+          :payload => (Base64.decode64(e['Payload']) unless e['Payload'].nil?) }
       end
     end
-
   end
 end

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -3,8 +3,7 @@ require 'faraday'
 
 module Diplomat
   class Service < Diplomat::RestClient
-
-    @access_methods = [ :get, :register, :deregister ]
+    @access_methods = [:get, :register, :deregister]
 
     # Get a service by it's key
     # @param key [String] the key
@@ -12,13 +11,12 @@ module Diplomat
     # @param options [Hash] :wait string for wait time and :index for index of last query
     # @param meta [Hash] output structure containing header information about the request (index)
     # @return [OpenStruct] all data associated with the service
-    def get key, scope=:first, options=nil, meta=nil
-
+    def get(key, scope = :first, options = nil, meta = nil)
       url = ["/v1/catalog/service/#{key}"]
-      url << use_named_parameter('wait', options[:wait]) if options and options[:wait]
-      url << use_named_parameter('index', options[:index]) if options and options[:index]
-      url << use_named_parameter('dc', options[:dc]) if options and options[:dc]
-      url << use_named_parameter('tag', options[:tag]) if options and options[:tag]
+      url << use_named_parameter('wait', options[:wait]) if options && options[:wait]
+      url << use_named_parameter('index', options[:index]) if options && options[:index]
+      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
+      url << use_named_parameter('tag', options[:tag]) if options && options[:tag]
 
       # If the request fails, it's probably due to a bad path
       # so return a PathNotFound error.
@@ -28,17 +26,17 @@ module Diplomat
         raise Diplomat::PathNotFound
       end
 
-      if meta and ret.headers
-        meta[:index] = ret.headers["x-consul-index"]
-        meta[:knownleader] = ret.headers["x-consul-knownleader"]
-        meta[:lastcontact] = ret.headers["x-consul-lastcontact"]
+      if meta && ret.headers
+        meta[:index] = ret.headers['x-consul-index']
+        meta[:knownleader] = ret.headers['x-consul-knownleader']
+        meta[:lastcontact] = ret.headers['x-consul-lastcontact']
       end
 
       if scope == :all
         return JSON.parse(ret.body).map { |service| OpenStruct.new service }
       end
 
-      return OpenStruct.new JSON.parse(ret.body).first
+      OpenStruct.new JSON.parse(ret.body).first
     end
 
     # Register a service
@@ -47,7 +45,7 @@ module Diplomat
     def register(definition)
       json_definition = JSON.dump(definition)
       register = @conn.put '/v1/agent/service/register', json_definition
-      return register.status == 200
+      register.status == 200
     end
 
     # De-register a service
@@ -55,7 +53,7 @@ module Diplomat
     # @return [Boolean]
     def deregister(service_name)
       deregister = @conn.get "/v1/agent/service/deregister/#{service_name}"
-      return deregister.status == 200
+      deregister.status == 200
     end
   end
 end

--- a/lib/diplomat/session.rb
+++ b/lib/diplomat/session.rb
@@ -2,47 +2,48 @@ require 'faraday'
 
 module Diplomat
   class Session < Diplomat::RestClient
-
-    @access_methods = [ :create, :destroy, :list, :renew ]
+    @access_methods = [:create, :destroy, :list, :renew]
 
     # Create a new session
     # @param value [Object] hash or json representation of the session arguments
     # @return [String] The sesssion id
-    def create value=nil
+    def create(value = nil)
       # TODO: only certain keys are recognised in a session create request,
       # should raise an error on others.
       raw = @conn.put do |req|
-        req.url "/v1/session/create"
-        req.body = (if value.kind_of?(String) then value else JSON.generate(value) end) unless value.nil?
+        req.url '/v1/session/create'
+        unless value.nil?
+          value.is_a?(String) ? req.body = value : req.body = JSON.generate(value)
+        end
       end
       body = JSON.parse(raw.body)
-      return body["ID"]
+      body['ID']
     end
 
     # Destroy a session
     # @param id [String] session id
     # @return [nil]
-    def destroy id
+    def destroy(id)
       raw = @conn.put do |req|
         req.url "/v1/session/destroy/#{id}"
       end
-      return raw.body
+      raw.body
     end
-    
+
     # List sessions
     # @return [Struct]
     def list
       raw = @conn.get do |req|
-        req.url "/v1/session/list"
+        req.url '/v1/session/list'
       end
       JSON.parse(raw.body)
     end
-    
+
     # Renew session
     # @param id [String] session id
     # @return [Struct]
-    
-    def renew id
+
+    def renew(id)
       raw = @conn.put do |req|
         req.url "/v1/session/renew/#{id}"
       end

--- a/lib/diplomat/version.rb
+++ b/lib/diplomat/version.rb
@@ -1,3 +1,3 @@
 module Diplomat
-  VERSION = "0.13.2"
+  VERSION = '0.13.2'
 end

--- a/spec/check_spec.rb
+++ b/spec/check_spec.rb
@@ -3,69 +3,64 @@ require 'json'
 require 'base64'
 
 describe Diplomat::Check do
-
   let(:faraday) { fake }
 
-  context "check" do
-
-    it "checks" do
+  context 'check' do
+    it 'checks' do
       json = JSON.generate(
-              {
-                "service:redis"=> {
-                    "Node"=>"foobar",
-                    "CheckID"=>"service:redis",
-                    "Name"=>"Service 'redis' check",
-                    "Status"=>"passing",
-                    "Notes"=>"",
-                    "Output"=>"",
-                    "ServiceID"=>"redis",
-                    "ServiceName"=>"redis"}
-              }
+        'service:redis' => {
+          'Node' => 'foobar',
+          'CheckID' => 'service:redis',
+          'Name' => "Service 'redis' check",
+          'Status' => 'passing',
+          'Notes' => '',
+          'Output' => '',
+          'ServiceID' => 'redis',
+          'ServiceName' => 'redis'
+        }
       )
 
-      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+      faraday.stub(:get).and_return(OpenStruct.new(:body => json))
 
       check = Diplomat::Check.new(faraday)
 
-      expect(check.checks["service:redis"]["Node"]).to eq("foobar")
+      expect(check.checks['service:redis']['Node']).to eq('foobar')
     end
 
-    it "register_script" do
-      faraday.stub(:put).and_return(OpenStruct.new({ body: '', status: 200 }))
+    it 'register_script' do
+      faraday.stub(:put).and_return(OpenStruct.new(:body => '', :status => 200))
       check = Diplomat::Check.new(faraday)
-      expect(check.register_script("foobar-1", "Foobar", "Foobar test", "/script/test", "10s")).to eq(true)
+      expect(check.register_script('foobar-1', 'Foobar', 'Foobar test', '/script/test', '10s')).to eq(true)
     end
 
-    it "register_ttl" do
-      faraday.stub(:put).and_return(OpenStruct.new({ body: '', status: 200 }))
+    it 'register_ttl' do
+      faraday.stub(:put).and_return(OpenStruct.new(:body => '', :status => 200))
       check = Diplomat::Check.new(faraday)
-      expect(check.register_ttl("foobar-1", "Foobar", "Foobar test", "15s")).to eq(true)
+      expect(check.register_ttl('foobar-1', 'Foobar', 'Foobar test', '15s')).to eq(true)
     end
 
-    it "deregister" do
-      faraday.stub(:get).and_return(OpenStruct.new({ body: '', status: 200 }))
+    it 'deregister' do
+      faraday.stub(:get).and_return(OpenStruct.new(:body => '', :status => 200))
       check = Diplomat::Check.new(faraday)
-      expect(check.deregister("foobar-1")).to eq(true)
+      expect(check.deregister('foobar-1')).to eq(true)
     end
 
-    it "pass" do
-      faraday.stub(:get).and_return(OpenStruct.new({ body: '', status: 200 }))
+    it 'pass' do
+      faraday.stub(:get).and_return(OpenStruct.new(:body => '', :status => 200))
       check = Diplomat::Check.new(faraday)
-      expect(check.pass("foobar-1")).to eq(true)
+      expect(check.pass('foobar-1')).to eq(true)
     end
 
-    it "warn" do
-      faraday.stub(:get).and_return(OpenStruct.new({ body: '', status: 200 }))
+    it 'warn' do
+      faraday.stub(:get).and_return(OpenStruct.new(:body => '', :status => 200))
       check = Diplomat::Check.new(faraday)
-      expect(check.warn("foobar-1")).to eq(true)
+      expect(check.warn('foobar-1')).to eq(true)
     end
 
-    it "fail" do
-      faraday.stub(:get).and_return(OpenStruct.new({ body: '', status: 200 }))
+    it 'fail' do
+      faraday.stub(:get).and_return(OpenStruct.new(:body => '', :status => 200))
       check = Diplomat::Check.new(faraday)
-      expect(check.fail("foobar-1")).to eq(true)
+      expect(check.fail('foobar-1')).to eq(true)
     end
-
   end
-
 end

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -1,69 +1,68 @@
 require 'spec_helper'
 
 describe Diplomat do
-
-  describe "configuration" do
+  describe 'configuration' do
     before(:each) do
       expect(Diplomat.configuration).to_not be_nil
       expect(Diplomat.configuration).to be_a Diplomat::Configuration
       Diplomat.configuration = Diplomat::Configuration.new
     end
 
-    it "has configuration block"  do
+    it 'has configuration block' do
       expect { |b| Diplomat.configure(&b) }.to yield_control
     end
 
-    context "Default" do
+    context 'Default' do
       let(:config) { Diplomat.configuration }
 
-      it "Returns a Diplmant::Configuration" do
+      it 'Returns a Diplmant::Configuration' do
         expect(config).to be_a Diplomat::Configuration
       end
 
-      it "Returns a default URL" do
+      it 'Returns a default URL' do
         expect(config.url).to_not be_nil
         expect(config.url.length).to be > 0
       end
 
-      it "Returns no default middleware" do
+      it 'Returns no default middleware' do
         expect(config.middleware).to be_a(Array)
         expect(config.middleware.length).to eq(0)
       end
 
-      it "Returns an empty options hash" do
+      it 'Returns an empty options hash' do
         expect(config.options).to be_a(Hash)
         expect(config.options).to be_empty
       end
     end
 
-    context "Custom Configuration" do
-
+    context 'Custom Configuration' do
       class StubMiddleware
         def initialize(app, options = {})
           @app = app
           @options = options
         end
+
         def call(env)
           @app.call(env)
         end
       end
 
-      it "Sets the correct configuration" do
+      it 'Sets the correct configuration' do
         Diplomat.configure do |config|
-          config.url = "http://google.com"
-          config.acl_token = "f45cbd0b-5022-47ab-8640-4eaa7c1f40f1"
+          config.url = 'http://google.com'
+          config.acl_token = 'f45cbd0b-5022-47ab-8640-4eaa7c1f40f1'
           config.middleware = StubMiddleware
-          config.options = {ssl: { verify: true }}
+          config.options = { :ssl => { :verify => true } }
         end
 
-        expect(Diplomat.configuration.url).to eq("http://google.com")
-        expect(Diplomat.configuration.acl_token).to eq("f45cbd0b-5022-47ab-8640-4eaa7c1f40f1")
+        expect(Diplomat.configuration.url).to eq('http://google.com')
+        expect(Diplomat.configuration.acl_token).to eq('f45cbd0b-5022-47ab-8640-4eaa7c1f40f1')
         expect(Diplomat.configuration.middleware).to be_a(Array)
         expect(Diplomat.configuration.middleware.first).to eq(StubMiddleware)
-        expect(Diplomat.configuration.options).to eq({ssl: { verify: true }})
+        expect(Diplomat.configuration.options).to eq(:ssl => { :verify => true })
       end
 
-      it "Can set multiple middleware" do
+      it 'Can set multiple middleware' do
         Diplomat.configure do |config|
           config.middleware = [StubMiddleware, StubMiddleware, StubMiddleware]
         end

--- a/spec/datacenter_spec.rb
+++ b/spec/datacenter_spec.rb
@@ -3,62 +3,61 @@ require 'json'
 require 'base64'
 
 describe Diplomat::Datacenter do
-
   let(:faraday) { fake }
 
-  context "datacenters" do
-    let(:key_url) { "/v1/catalog/datacenters" }
-    let(:body) {
-      [ "dc1", "dc2" ]
-    }
-    let(:headers) {
+  context 'datacenters' do
+    let(:key_url) { '/v1/catalog/datacenters' }
+    let(:body) do
+      %w(dc1 dc2)
+    end
+    let(:headers) do
       {
-        "x-consul-index"        => "8",
-        "x-consul-knownleader"  => "true",
-        "x-consul-lastcontact"  => "0"
+        'x-consul-index'        => '8',
+        'x-consul-knownleader'  => 'true',
+        'x-consul-lastcontact'  => '0'
       }
-    }
+    end
 
-    describe "GET" do
-      it "returns dcs" do
+    describe 'GET' do
+      it 'returns dcs' do
         json = JSON.generate(body)
 
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json }))
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(:body => json))
 
         datacenters = Diplomat::Datacenter.new(faraday)
 
-        expect(datacenters.get().size).to eq(2)
-        expect(datacenters.get()[0]).to eq("dc1")
+        expect(datacenters.get.size).to eq(2)
+        expect(datacenters.get[0]).to eq('dc1')
       end
     end
 
-    describe "GET With headers" do
-      it "empty headers" do
+    describe 'GET With headers' do
+      it 'empty headers' do
         json = JSON.generate(body)
 
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json, headers: nil }))
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(:body => json, :headers => nil))
 
         datacenters = Diplomat::Datacenter.new(faraday)
 
         meta = {}
         expect(datacenters.get(meta).size).to eq(2)
-        expect(datacenters.get(meta)[0]).to eq("dc1")
+        expect(datacenters.get(meta)[0]).to eq('dc1')
         expect(meta.length).to eq(0)
       end
 
-      it "filled headers" do
+      it 'filled headers' do
         json = JSON.generate(body)
 
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json, headers: headers }))
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(:body => json, :headers => headers))
 
         datacenters = Diplomat::Datacenter.new(faraday)
 
         meta = {}
         s = datacenters.get(meta)
-        expect(s[0]).to eq("dc1")
-        expect(meta[:index]).to eq("8")
-        expect(meta[:knownleader]).to eq("true")
-        expect(meta[:lastcontact]).to eq("0")
+        expect(s[0]).to eq('dc1')
+        expect(meta[:index]).to eq('8')
+        expect(meta[:knownleader]).to eq('true')
+        expect(meta[:lastcontact]).to eq('0')
       end
     end
   end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -3,7 +3,6 @@ require 'json'
 require 'base64'
 
 describe Diplomat::Event do
-
   before :all do
     @empty_json = '[]'
     @events_json =
@@ -30,138 +29,140 @@ describe Diplomat::Event do
       {"ID":"134538e5-2ad7-67b2-cc3a-422526d145fa","Name":"test","Payload":"eyBrZXk6IDEwIH0=","NodeFilter":"","ServiceFilter":"","TagFilter":"","Version":1,"LTime":336},
       {"ID":"cc4e38a8-7faa-b3b2-b5cb-7ba9839b7b5b","Name":"test","Payload":"eyBrZXk6IDExIH0=","NodeFilter":"","ServiceFilter":"","TagFilter":"","Version":1,"LTime":337}]'
     @events_expected =
-     [{name: "test", payload: "{ key: 1 }"},
-      {name: "test", payload: "{ key: 2 }"},
-      {name: "test", payload: "{ key: 3 }"},
-      {name: "test", payload: "{ key: 4 }"},
-      {name: "test", payload: "{ key: 5 }"},
-      {name: "test", payload: "{ key: 6 }"},
-      {name: "test", payload: "{ key: 7 }"},
-      {name: "test", payload: "{ key: 8 }"},
-      {name: "test", payload: "{ key: 9 }"},
-      {name: "test", payload: "{ key: 10 }"}]
+     [{ name: 'test', payload: '{ key: 1 }' },
+      { name: 'test', payload: '{ key: 2 }' },
+      { name: 'test', payload: '{ key: 3 }' },
+      { name: 'test', payload: '{ key: 4 }' },
+      { name: 'test', payload: '{ key: 5 }' },
+      { name: 'test', payload: '{ key: 6 }' },
+      { name: 'test', payload: '{ key: 7 }' },
+      { name: 'test', payload: '{ key: 8 }' },
+      { name: 'test', payload: '{ key: 9 }' },
+      { name: 'test', payload: '{ key: 10 }' }]
     @events_next_expected =
-     [{name: "test", payload: "{ key: 1 }"},
-      {name: "test", payload: "{ key: 2 }"},
-      {name: "test", payload: "{ key: 3 }"},
-      {name: "test", payload: "{ key: 4 }"},
-      {name: "test", payload: "{ key: 5 }"},
-      {name: "test", payload: "{ key: 6 }"},
-      {name: "test", payload: "{ key: 7 }"},
-      {name: "test", payload: "{ key: 8 }"},
-      {name: "test", payload: "{ key: 9 }"},
-      {name: "test", payload: "{ key: 10 }"},
-      {name: "test", payload: "{ key: 11 }"}]
-    @event_name = "test"
-    @event_first = { value: {name: "test", payload: "{ key: 1 }"}, token: "b8a5d478-c370-28b1-cd04-9547877bf767" }
-    @token_mid = "e0c7e975-fdc3-6c8b-fb8f-0a667ecb221c"
-    @event_mid   = { value: {name: "test", payload: "{ key: 6 }"}, token: "c5e1391b-1559-ca52-2ef5-ba9ab5808806" }
-    @event_last  = { value: {name: "test", payload: "{ key: 10 }"}, token: "134538e5-2ad7-67b2-cc3a-422526d145fa" }
-    @event_next  = { value: {name: "test", payload: "{ key: 11 }"}, token: "cc4e38a8-7faa-b3b2-b5cb-7ba9839b7b5b" }
+     [{ name: 'test', payload: '{ key: 1 }' },
+      { name: 'test', payload: '{ key: 2 }' },
+      { name: 'test', payload: '{ key: 3 }' },
+      { name: 'test', payload: '{ key: 4 }' },
+      { name: 'test', payload: '{ key: 5 }' },
+      { name: 'test', payload: '{ key: 6 }' },
+      { name: 'test', payload: '{ key: 7 }' },
+      { name: 'test', payload: '{ key: 8 }' },
+      { name: 'test', payload: '{ key: 9 }' },
+      { name: 'test', payload: '{ key: 10 }' },
+      { name: 'test', payload: '{ key: 11 }' }]
+    @event_name = 'test'
+    @event_first = { :value => { :name => 'test', :payload => '{ key: 1 }' }, :token => 'b8a5d478-c370-28b1-cd04-9547877bf767' }
+    @token_mid = 'e0c7e975-fdc3-6c8b-fb8f-0a667ecb221c'
+    @event_mid   = { :value => { :name => 'test', :payload => '{ key: 6 }' }, :token => 'c5e1391b-1559-ca52-2ef5-ba9ab5808806' }
+    @event_last  = { :value => { :name => 'test', :payload =>'{ key: 10 }' }, :token => '134538e5-2ad7-67b2-cc3a-422526d145fa' }
+    @event_next  = { :value => { :name => 'test', :payload => '{ key: 11 }' }, :token => 'cc4e38a8-7faa-b3b2-b5cb-7ba9839b7b5b' }
   end
 
+  describe '#get_all' do
+    context 'empty list' do
+      let(:faraday) { double('Faraday') }
 
-  describe "#get_all" do
-
-    context "empty list" do
-      let(:faraday) { double("Faraday") }
-
-      it "default args act the same as (:reject, _)" do
+      it 'default args act the same as (:reject, _)' do
         expect(faraday).to receive(:get).and_return(
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @empty_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @empty_json)
         )
         ev = Diplomat::Event.new(faraday)
-        expect{ev.get_all(@event_name)}.to raise_error(Diplomat::EventNotFound, @event_name)
+        expect { ev.get_all(@event_name) }.to raise_error(Diplomat::EventNotFound, @event_name)
       end
-      it "throws when asked to :reject" do
+
+      it 'throws when asked to :reject' do
         expect(faraday).to receive(:get).and_return(
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @empty_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @empty_json)
         )
         ev = Diplomat::Event.new(faraday)
-        expect{ev.get_all(@event_name, :reject)}.to raise_error(Diplomat::EventNotFound, @event_name)
+        expect { ev.get_all(@event_name, :reject) }.to raise_error(Diplomat::EventNotFound, @event_name)
       end
-      it "retries and returns when asked to :wait" do
+
+      it 'retries and returns when asked to :wait' do
         expect(faraday).to receive(:get).twice.and_return(
-            OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @empty_json }),
-            OpenStruct.new({ status: 200, headers: {"x-consul-index" => "69"}, body: @events_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @empty_json),
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '69' }, :body => @events_json)
         )
         ev = Diplomat::Event.new(faraday)
         expect(ev.get_all(@event_name, :wait)).to eql(@events_expected)
       end
     end
 
-    context "non-empty list" do
-      let(:faraday) { double("Faraday") }
+    context 'non-empty list' do
+      let(:faraday) { double('Faraday') }
 
-      it "default args act the same as (_, :return)" do
+      it 'default args act the same as (_, :return)' do
         expect(faraday).to receive(:get).and_return(
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @events_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @events_json)
         )
         ev = Diplomat::Event.new(faraday)
         expect(ev.get_all(@event_name)).to eql(@events_expected)
       end
-      it "throws when asked to :reject" do
+
+      it 'throws when asked to :reject' do
         expect(faraday).to receive(:get).and_return(
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @events_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @events_json)
         )
         ev = Diplomat::Event.new(faraday)
-        expect{ev.get_all(@event_name, :reject, :reject)}.to raise_error(Diplomat::EventAlreadyExists, @event_name)
+        expect { ev.get_all(@event_name, :reject, :reject) }.to raise_error(Diplomat::EventAlreadyExists, @event_name)
       end
-      it "returns when asked to :return" do
+
+      it 'returns when asked to :return' do
         expect(faraday).to receive(:get).and_return(
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @events_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @events_json)
         )
         ev = Diplomat::Event.new(faraday)
         expect(ev.get_all(@event_name, :reject, :return)).to eql(@events_expected)
       end
-      it "retries and returns when asked to :wait" do
+
+      it 'retries and returns when asked to :wait' do
         expect(faraday).to receive(:get).twice.and_return(
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @events_json }),
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "69"}, body: @events_next_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @events_json),
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '69' }, :body => @events_next_json)
         )
         ev = Diplomat::Event.new(faraday)
         expect(ev.get_all(@event_name, :reject, :wait)).to eql(@events_next_expected)
       end
     end
-
   end
 
+  describe '#get' do
+    context 'non-empty list' do
+      let(:faraday) { double('Faraday') }
 
-  describe "#get" do
-
-    context "non-empty list" do
-      let(:faraday) { double("Faraday") }
-
-      it "gets first item" do
+      it 'gets first item' do
         expect(faraday).to receive(:get).and_return(
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @events_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @events_json)
         )
         ev = Diplomat::Event.new(faraday)
         expect(ev.get(@event_name, :first)).to eql(@event_first)
       end
-      it "gets last item" do
+
+      it 'gets last item' do
         expect(faraday).to receive(:get).and_return(
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @events_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @events_json)
         )
         ev = Diplomat::Event.new(faraday)
         expect(ev.get(@event_name, :last)).to eql(@event_last)
       end
-      it "gets mid-sequence item" do
+
+      it 'gets mid-sequence item' do
         expect(faraday).to receive(:get).and_return(
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @events_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @events_json)
         )
         ev = Diplomat::Event.new(faraday)
         expect(ev.get(@event_name, @token_mid)).to eql(@event_mid)
       end
-      it "retries and returns next item" do
+
+      it 'retries and returns next item' do
         expect(faraday).to receive(:get).twice.and_return(
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "42"}, body: @events_json }),
-          OpenStruct.new({ status: 200, headers: {"x-consul-index" => "69"}, body: @events_next_json })
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '42' }, :body => @events_json),
+          OpenStruct.new(:status => 200, :headers => { 'x-consul-index' => '69' }, :body => @events_next_json)
         )
         ev = Diplomat::Event.new(faraday)
         expect(ev.get(@event_name, :next)).to eql(@event_next)
       end
     end
-
   end
 end

--- a/spec/health_spec.rb
+++ b/spec/health_spec.rb
@@ -3,12 +3,10 @@ require 'json'
 require 'base64'
 
 describe Diplomat::Health do
-
   let(:faraday) { fake }
 
-  context "health" do
-
-    it "node" do
+  context 'health' do
+    it 'node' do
       json = <<EOF
       [
             {
@@ -34,14 +32,14 @@ describe Diplomat::Health do
         ]
 EOF
 
-      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+      faraday.stub(:get).and_return(OpenStruct.new(:body => json))
 
       health = Diplomat::Health.new(faraday)
 
-      expect(health.node("foobar")[0]["Node"]).to eq("foobar")
+      expect(health.node('foobar')[0]['Node']).to eq('foobar')
     end
 
-    it "checks" do
+    it 'checks' do
       json = <<EOF
 [
     {
@@ -57,14 +55,14 @@ EOF
 ]
 EOF
 
-      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+      faraday.stub(:get).and_return(OpenStruct.new(:body => json))
 
       health = Diplomat::Health.new(faraday)
 
-      expect(health.checks("foobar")[0]["Node"]).to eq("foobar")
+      expect(health.checks('foobar')[0]['Node']).to eq('foobar')
     end
 
-    it "service" do
+    it 'service' do
       json = <<EOF
 [
     {
@@ -104,15 +102,15 @@ EOF
 ]
 EOF
 
-      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+      faraday.stub(:get).and_return(OpenStruct.new(:body => json))
 
       health = Diplomat::Health.new(faraday)
 
-      expect(health.service("foobar")[0]["Node"]["Node"]).to eq("foobar")
+      expect(health.service('foobar')[0]['Node']['Node']).to eq('foobar')
     end
 
-it "state" do
-      json = <<EOF
+    it 'state' do
+          json = <<EOF
 [
     {
         "Node": "foobar",
@@ -137,14 +135,11 @@ it "state" do
 ]
 EOF
 
-      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+          faraday.stub(:get).and_return(OpenStruct.new(:body => json))
 
-      health = Diplomat::Health.new(faraday)
+          health = Diplomat::Health.new(faraday)
 
-      expect(health.state("foobar")[0]["Node"]).to eq("foobar")
-    end
-
-
+          expect(health.state('foobar')[0]['Node']).to eq('foobar')
+        end
   end
-
 end

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -3,169 +3,172 @@ require 'json'
 require 'base64'
 
 describe Diplomat::Kv do
-
   let(:faraday) { fake }
 
-  context "keys" do
-    let(:key) { "key" }
+  context 'keys' do
+    let(:key) { 'key' }
     let(:key_url) { "/v1/kv/#{key}" }
-    let(:key_params) { "toast" }
+    let(:key_params) { 'toast' }
     let(:modify_index) { 99 }
-    let(:valid_acl_token) { "f45cbd0b-5022-47ab-8640-4eaa7c1f40f1" }
+    let(:valid_acl_token) { 'f45cbd0b-5022-47ab-8640-4eaa7c1f40f1' }
 
-    describe "#get" do
-      context "Datacenter filter" do
-        it "GET" do
-          faraday.double()
+    describe '#get' do
+      context 'Datacenter filter' do
+        it 'GET' do
+          faraday.double
           kv = Diplomat::Kv.new(faraday)
           expect(faraday).to receive(:get)
-                              .with(/dc=bar/)
-                              .and_return(OpenStruct.new({ status: 200, body: JSON.generate([]) }))
-          kv.get('foo', dc: 'bar')
+            .with(/dc=bar/)
+            .and_return(OpenStruct.new(:status => 200, :body => JSON.generate([])))
+          kv.get('foo', :dc => 'bar')
         end
       end
 
-      context "ACLs NOT enabled, recurse option ON" do
-        it "GET" do
+      context 'ACLs NOT enabled, recurse option ON' do
+        it 'GET' do
           json = JSON.generate([
             {
-              "Key"   => key + 'dewfr',
-              "Value" => Base64.encode64(key_params),
-              "Flags" => 0
+              'Key'   => key + 'dewfr',
+              'Value' => Base64.encode64(key_params),
+              'Flags' => 0
             },
             {
-              "Key"   => key,
-              "Value" => Base64.encode64(key_params),
-              "Flags" => 0
+              'Key'   => key,
+              'Value' => Base64.encode64(key_params),
+              'Flags' => 0
             },
             {
-              "Key"   => key + 'iamnil',
-              "Value" => nil,
-              "Flags" => 0
+              'Key'   => key + 'iamnil',
+              'Value' => nil,
+              'Flags' => 0
             }])
-          faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
+          faraday.stub(:get).and_return(OpenStruct.new(:status => 200, :body => json))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key?recurse")).to eql([
-            { key: 'keydewfr', value: "toast" },
-            { key: 'key', value: "toast" }
+          expect(kv.get('key?recurse')).to eql([
+            { :key => 'keydewfr', :value => 'toast' },
+            { :key => 'key', :value => 'toast' }
           ])
         end
       end
 
-      context "ACLs NOT enabled" do
-        it "GET" do
+      context 'ACLs NOT enabled' do
+        it 'GET' do
           json = JSON.generate([{
-            "Key"   => key,
-            "Value" => Base64.encode64(key_params),
-            "Flags" => 0
+            'Key'   => key,
+            'Value' => Base64.encode64(key_params),
+            'Flags' => 0
           }])
-          faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
+          faraday.stub(:get).and_return(OpenStruct.new(:status => 200, :body => json))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key")).to eq("toast")
+          expect(kv.get('key')).to eq('toast')
         end
-        it "GET with consistency param" do
-          options = {:consistency => "consistent"}
+        it 'GET with consistency param' do
+          options = { :consistency => 'consistent' }
           json = JSON.generate([{
-            "Key"   => key,
-            "Value" => Base64.encode64(key_params),
-            "Flags" => 0
+            'Key'   => key,
+            'Value' => Base64.encode64(key_params),
+            'Flags' => 0
           }])
-          faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
+          faraday.stub(:get).and_return(OpenStruct.new(:status => 200, :body => json))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key", options)).to eq("toast")
-        end
-      end
-      context "ACLs enabled, without valid_acl_token" do
-        it "GET with ACLs enabled, no valid_acl_token" do
-          json = JSON.generate([{
-            "Key"   => key,
-            "Value" => Base64.encode64("Faraday::ResourceNotFound: the server responded with status 404"),
-            "Flags" => 0
-          }])
-          faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
-          kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key")).to eq("Faraday::ResourceNotFound: the server responded with status 404")
-        end
-        it "GET with consistency param, without valid_acl_token" do
-          options = {:consistency => "consistent"}
-          json = JSON.generate([{
-            "Key"   => key,
-            "Value" => Base64.encode64("Faraday::ResourceNotFound: the server responded with status 404"),
-            "Flags" => 0
-          }])
-          faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
-          kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key", options)).to eq("Faraday::ResourceNotFound: the server responded with status 404")
+          expect(kv.get('key', options)).to eq('toast')
         end
       end
-      context "ACLs enabled, with valid_acl_token" do
-        it "GET with ACLs enabled, valid_acl_token" do
+      context 'ACLs enabled, without valid_acl_token' do
+        it 'GET with ACLs enabled, no valid_acl_token' do
           json = JSON.generate([{
-            "Key"   => key,
-            "Value" => Base64.encode64(key_params),
-            "Flags" => 0
+            'Key'   => key,
+            'Value' => Base64.encode64('Faraday::ResourceNotFound: the server responded with status 404'),
+            'Flags' => 0
           }])
-          faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
-          Diplomat.configuration.acl_token = valid_acl_token
+          faraday.stub(:get).and_return(OpenStruct.new(:status => 200, :body => json))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key")).to eq("toast")
+          expect(kv.get('key')).to eq('Faraday::ResourceNotFound: the server responded with status 404')
         end
-        it "GET with consistency param, with valid_acl_token" do
-          options = {:consistency => "consistent"}
+        it 'GET with consistency param, without valid_acl_token' do
+          options = { consistency: 'consistent' }
           json = JSON.generate([{
-            "Key"   => key,
-            "Value" => Base64.encode64(key_params),
-            "Flags" => 0
+            'Key'   => key,
+            'Value' => Base64.encode64('Faraday::ResourceNotFound: the server responded with status 404'),
+            'Flags' => 0
           }])
-          faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
+          faraday.stub(:get).and_return(OpenStruct.new(:status => 200, :body => json))
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.get('key', options)).to eq('Faraday::ResourceNotFound: the server responded with status 404')
+        end
+      end
+      context 'ACLs enabled, with valid_acl_token' do
+        it 'GET with ACLs enabled, valid_acl_token' do
+          json = JSON.generate([{
+            'Key'   => key,
+            'Value' => Base64.encode64(key_params),
+            'Flags' => 0
+          }])
+          faraday.stub(:get).and_return(OpenStruct.new(:status => 200, :body => json))
           Diplomat.configuration.acl_token = valid_acl_token
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key", options)).to eq("toast")
+          expect(kv.get('key')).to eq('toast')
+        end
+        it 'GET with consistency param, with valid_acl_token' do
+          options = { consistency: 'consistent' }
+          json = JSON.generate([{
+            'Key'   => key,
+            'Value' => Base64.encode64(key_params),
+            'Flags' => 0
+          }])
+          faraday.stub(:get).and_return(OpenStruct.new(:status => 200, :body => json))
+          Diplomat.configuration.acl_token = valid_acl_token
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.get('key', options)).to eq('toast')
         end
       end
     end
 
-    describe "#put" do
-      context "ACLs NOT enabled" do
-        it "PUT" do
-          faraday.stub(:put).and_return(OpenStruct.new({ status: 200, body: "true"}))
+    describe '#put' do
+      context 'ACLs NOT enabled' do
+        it 'PUT' do
+          faraday.stub(:put).and_return(OpenStruct.new(:status => 200, :body => 'true'))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params)).to eq(true)
           expect(kv.value).to eq(key_params)
         end
-        it "PUT with CAS param" do
-          options = {:cas => modify_index}
-          faraday.stub(:put).and_return(OpenStruct.new({ status: 200, body: "true"}))
+        it 'PUT with CAS param' do
+          options = { cas: modify_index }
+          faraday.stub(:put).and_return(OpenStruct.new(:status => 200, :body => 'true'))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params, options)).to eq(true)
           expect(kv.value).to eq(key_params)
         end
       end
-      context "ACLs enabled, without valid_acl_token" do
-        it "PUT with ACLs enabled, no valid_acl_token" do
-          faraday.stub(:put).and_return(OpenStruct.new({ status: 200, body: "false" }))
+
+      context 'ACLs enabled, without valid_acl_token' do
+        it 'PUT with ACLs enabled, no valid_acl_token' do
+          faraday.stub(:put).and_return(OpenStruct.new(:status => 200, :body => 'false'))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params)).to eq(false)
         end
-        it "PUT with CAS param, without valid_acl_token" do
-          options = {:cas => modify_index}
-          faraday.stub(:put).and_return(OpenStruct.new({ status: 200, body: "false"}))
+
+        it 'PUT with CAS param, without valid_acl_token' do
+          options = { cas: modify_index }
+          faraday.stub(:put).and_return(OpenStruct.new(:status => 200, :body => 'false'))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params, options)).to eq(false)
         end
       end
-      context "ACLs enabled, with valid_acl_token" do
-        it "PUT with ACLs enabled, valid_acl_token" do
-          faraday.stub(:put).and_return(OpenStruct.new({ status: 200, body: "true"}))
+
+      context 'ACLs enabled, with valid_acl_token' do
+        it 'PUT with ACLs enabled, valid_acl_token' do
+          faraday.stub(:put).and_return(OpenStruct.new(:status => 200, :body => 'true'))
           Diplomat.configuration.acl_token = valid_acl_token
           kv = Diplomat::Kv.new(faraday)
 
           expect(kv.put(key, key_params)).to eq(true)
           expect(kv.value).to eq(key_params)
         end
-        it "PUT with CAS param" do
-          options = {:cas => modify_index}
-          faraday.stub(:put).and_return(OpenStruct.new({ status: 200, body: "true"}))
+
+        it 'PUT with CAS param' do
+          options = { cas: modify_index }
+          faraday.stub(:put).and_return(OpenStruct.new(:status => 200, :body => 'true'))
           Diplomat.configuration.acl_token = valid_acl_token
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params, options)).to eq(true)
@@ -174,24 +177,26 @@ describe Diplomat::Kv do
       end
     end
 
-    describe "#delete" do
-      context "ACLs NOT enabled" do
-        it "DELETE" do
-          faraday.stub(:delete).and_return(OpenStruct.new({ status: 200}))
+    describe '#delete' do
+      context 'ACLs NOT enabled' do
+        it 'DELETE' do
+          faraday.stub(:delete).and_return(OpenStruct.new(:status => 200))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.delete(key).status).to eq 200
         end
       end
-      context "ACLs enabled, without valid_acl_token" do
-        it "DELETE" do
-          faraday.stub(:delete).and_return(OpenStruct.new({ status: 403}))
+
+      context 'ACLs enabled, without valid_acl_token' do
+        it 'DELETE' do
+          faraday.stub(:delete).and_return(OpenStruct.new(:status => 403))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.delete(key).status).to eq 403
         end
       end
-      context "ACLs enabled, with valid_acl_token" do
-        it "DELETE" do
-          faraday.stub(:delete).and_return(OpenStruct.new({ status: 200}))
+
+      context 'ACLs enabled, with valid_acl_token' do
+        it 'DELETE' do
+          faraday.stub(:delete).and_return(OpenStruct.new(:status => 200))
           Diplomat.configuration.acl_token = valid_acl_token
           kv = Diplomat::Kv.new(faraday)
           expect(kv.delete(key).status).to eq 200
@@ -199,14 +204,11 @@ describe Diplomat::Kv do
       end
     end
 
-    it "namespaces" do
-      faraday.stub(:put).and_return(OpenStruct.new({ status: 200, body: "true"}))
+    it 'namespaces' do
+      faraday.stub(:put).and_return(OpenStruct.new(:status => 200, :body => 'true'))
       kv = Diplomat::Kv.new(faraday)
-
       expect(kv.put("toast/#{key}", key_params)).to eq(true)
       expect(kv.value).to eq(key_params)
     end
-
   end
-
 end

--- a/spec/lock_spec.rb
+++ b/spec/lock_spec.rb
@@ -3,37 +3,25 @@ require 'json'
 require 'base64'
 
 describe Diplomat::Lock do
-
   let(:faraday) { fake }
 
-  context "lock" do
-
-    it "acquire" do
-
-      faraday.stub(:put).and_return(OpenStruct.new({ body: "true" }))
-
+  context 'lock' do
+    it 'acquire' do
+      faraday.stub(:put).and_return(OpenStruct.new(:body => 'true'))
       lock = Diplomat::Lock.new(faraday)
-
-      expect(lock.acquire("fc5ca01a-c317-39ea-05e8-221da00d3a12","/lock/key")).to eq(true)
+      expect(lock.acquire('fc5ca01a-c317-39ea-05e8-221da00d3a12', '/lock/key')).to eq(true)
     end
 
-    it "wait_to_acquire" do
-
-      faraday.stub(:put).and_return(OpenStruct.new({ body: "true" }))
-
+    it 'wait_to_acquire' do
+      faraday.stub(:put).and_return(OpenStruct.new(:body => 'true'))
       lock = Diplomat::Lock.new(faraday)
-
-      expect(lock.wait_to_acquire("fc5ca01a-c317-39ea-05e8-221da00d3a12","/lock/key",2)).to eq(true)
+      expect(lock.wait_to_acquire('fc5ca01a-c317-39ea-05e8-221da00d3a12', '/lock/key', 2)).to eq(true)
     end
 
-    it "release" do
-
-      faraday.stub(:put).and_return(OpenStruct.new({ body: "true"}))
+    it 'release' do
+      faraday.stub(:put).and_return(OpenStruct.new(:body => 'true'))
       lock = Diplomat::Lock.new(faraday)
-
-      expect(lock.release("fc5ca01a-c317-39ea-05e8-221da00d3a12","/lock/key")).to eq("true")
+      expect(lock.release('fc5ca01a-c317-39ea-05e8-221da00d3a12', '/lock/key')).to eq('true')
     end
-
   end
-
 end

--- a/spec/members_spec.rb
+++ b/spec/members_spec.rb
@@ -3,40 +3,34 @@ require 'json'
 require 'base64'
 
 describe Diplomat::Members do
-
   let(:faraday) { fake }
 
-  context "member" do
-
-    it "GET" do
+  context 'member' do
+    it 'GET' do
       json = JSON.generate(
         [{
-          "Name" => "foobar",
-          "Addr" => "10.1.10.12",
-          "Port" => 8301,
-          "Tags" => {
-            "bootstrap" => "1",
-            "dc" => "dc1",
-            "port" => 8300,
-            "role" => "consul",
+          'Name' => 'foobar',
+          'Addr' => '10.1.10.12',
+          'Port' => 8301,
+          'Tags' => {
+            'bootstrap' => '1',
+            'dc' => 'dc1',
+            'port' => 8300,
+            'role' => 'consul',
           },
-          "Status" =>  1,
-          "ProtocolMin" => 1,
-          "ProtocolMax" => 2,
-          "ProtocolCur" => 2,
-          "DelegateMin" => 1,
-          "DelegateMax" => 3,
-          "DelegateCur" => 3
+          'Status' => 1,
+          'ProtocolMin' => 1,
+          'ProtocolMax' => 2,
+          'ProtocolCur' => 2,
+          'DelegateMin' => 1,
+          'DelegateMax' => 3,
+          'DelegateCur' => 3
         }]
       )
 
-      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
-
+      faraday.stub(:get).and_return(OpenStruct.new(:body => json))
       members = Diplomat::Members.new(faraday)
-
-      expect(members.get[0]["Name"]).to eq("foobar")
+      expect(members.get[0]['Name']).to eq('foobar')
     end
-
   end
-
 end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -3,191 +3,178 @@ require 'json'
 require 'base64'
 
 describe Diplomat::Service do
-
   let(:faraday) { fake }
 
-  context "services" do
-    let(:key) { "toast" }
+  context 'services' do
+    let(:key) { 'toast' }
     let(:key_url) { "/v1/catalog/service/#{key}" }
     let(:key_url_with_alloptions) { "/v1/catalog/service/#{key}?wait=5m&index=3&dc=somedc" }
     let(:key_url_with_indexoption) { "/v1/catalog/service/#{key}?index=5" }
     let(:key_url_with_waitoption) { "/v1/catalog/service/#{key}?wait=6s" }
     let(:key_url_with_datacenteroption) { "/v1/catalog/service/#{key}?dc=somedc" }
     let(:key_url_with_tagoption) { "/v1/catalog/service/#{key}?tag=sometag" }
-    let(:body) {
+    let(:body) do
       [
         {
-          "Node"        => "foo",
-          "Address"     => "10.1.10.12",
-          "ServiceID"   => key,
-          "ServiceName" => key,
-          "ServiceTags" => ['sometag'],
-          "ServicePort" => "70457"
+          'Node'        => 'foo',
+          'Address'     => '10.1.10.12',
+          'ServiceID'   => key,
+          'ServiceName' => key,
+          'ServiceTags' => ['sometag'],
+          'ServicePort' => '70457'
         },
         {
-          "Node"        => "bar",
-          "Address"     => "10.1.10.13",
-          "ServiceID"   => key,
-          "ServiceName" => key,
-          "ServiceTags" => ['sometag', 'anothertag'],
-          "ServicePort" => "70457"
+          'Node'        => 'bar',
+          'Address'     => '10.1.10.13',
+          'ServiceID'   => key,
+          'ServiceName' => key,
+          'ServiceTags' => %w(sometag anothertag),
+          'ServicePort' => '70457'
         }
       ]
-    }
-    let(:headers) {
+    end
+    let(:headers) do
       {
-        "x-consul-index"        => "8",
-        "x-consul-knownleader"  => "true",
-        "x-consul-lastcontact"  => "0"
+        'x-consul-index'        => '8',
+        'x-consul-knownleader'  => 'true',
+        'x-consul-lastcontact'  => '0'
       }
-    }
+    end
 
-    describe "GET" do
-      it ":first" do
+    describe 'GET' do
+      it ':first' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json }))
-
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(:body => json))
         service = Diplomat::Service.new(faraday)
-
-        expect(service.get("toast").Node).to eq("foo")
+        expect(service.get('toast').Node).to eq('foo')
       end
 
-      it ":all" do
+      it ':all' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json }))
-
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(:body => json))
         service = Diplomat::Service.new(faraday)
-
-        expect(service.get("toast", :all).size).to eq(2)
-        expect(service.get("toast", :all)[0].Node).to eq("foo")
+        expect(service.get('toast', :all).size).to eq(2)
+        expect(service.get('toast', :all)[0].Node).to eq('foo')
       end
     end
 
-    describe "GET With Options" do
-      it "empty headers" do
+    describe 'GET With Options' do
+      it 'empty headers' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json, headers: nil }))
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(:body => json, :headers => nil))
 
         service = Diplomat::Service.new(faraday)
 
         meta = {}
-        s = service.get("toast", :first, {}, meta)
-        expect(s.Node).to eq("foo")
+        s = service.get('toast', :first, {}, meta)
+        expect(s.Node).to eq('foo')
         expect(meta.length).to eq(0)
       end
 
-      it "filled headers" do
+      it 'filled headers' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json, headers: headers }))
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(:body => json, :headers => headers))
 
         service = Diplomat::Service.new(faraday)
 
         meta = {}
-        s = service.get("toast", :first, {}, meta)
-        expect(s.Node).to eq("foo")
-        expect(meta[:index]).to eq("8")
-        expect(meta[:knownleader]).to eq("true")
-        expect(meta[:lastcontact]).to eq("0")
+        s = service.get('toast', :first, {}, meta)
+        expect(s.Node).to eq('foo')
+        expect(meta[:index]).to eq('8')
+        expect(meta[:knownleader]).to eq('true')
+        expect(meta[:lastcontact]).to eq('0')
       end
 
-      it "index option" do
+      it 'index option' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url_with_indexoption).and_return(OpenStruct.new({ body: json, headers: headers }))
+        faraday.stub(:get).with(key_url_with_indexoption).and_return(OpenStruct.new(:body => json, :headers => headers))
 
         service = Diplomat::Service.new(faraday)
 
-        options = { :index => "5" }
-        s = service.get("toast", :first, options)
-        expect(s.Node).to eq("foo")
+        options = { :index => '5' }
+        s = service.get('toast', :first, options)
+        expect(s.Node).to eq('foo')
       end
 
-      it "wait option" do
+      it 'wait option' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url_with_waitoption).and_return(OpenStruct.new({ body: json, headers: headers }))
+        faraday.stub(:get).with(key_url_with_waitoption).and_return(OpenStruct.new(:body => json, :headers => headers))
 
         service = Diplomat::Service.new(faraday)
 
-        options = { :wait => "6s" }
-        s = service.get("toast", :first, options)
-        expect(s.Node).to eq("foo")
+        options = { :wait => '6s' }
+        s = service.get('toast', :first, options)
+        expect(s.Node).to eq('foo')
       end
 
-      it "datacenter option" do
+      it 'datacenter option' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url_with_datacenteroption).and_return(OpenStruct.new({ body: json, headers: headers }))
+        faraday.stub(:get).with(key_url_with_datacenteroption).and_return(OpenStruct.new(:body => json, :headers => headers))
 
         service = Diplomat::Service.new(faraday)
 
-        options = { :dc => "somedc" }
-        s = service.get("toast", :first, options)
-        expect(s.Node).to eq("foo")
+        options = { :dc => 'somedc' }
+        s = service.get('toast', :first, options)
+        expect(s.Node).to eq('foo')
       end
 
-      it "bad datacenter option" do
-        faraday = double()
+      it 'bad datacenter option' do
+        faraday = double
 
         allow(faraday).to receive(:get)
-                            .with(key_url_with_datacenteroption)
-                            .and_raise(
-                              Faraday::ClientError.new({}, 500)
-                            )
+          .with(key_url_with_datacenteroption)
+          .and_raise(
+            Faraday::ClientError.new({}, 500)
+          )
 
         service = Diplomat::Service.new(faraday)
-        options = { :dc => "somedc" }
-        expect{ service.get("toast", :first, options) }.to raise_error(Diplomat::PathNotFound)
+        options = { :dc => 'somedc' }
+        expect { service.get('toast', :first, options) }.to raise_error(Diplomat::PathNotFound)
       end
 
-      it "tag option" do
+      it 'tag option' do
         json = JSON.generate(body)
 
-        faraday.stub(:get).with(key_url_with_tagoption).and_return(OpenStruct.new({ body: json, headers: headers }))
+        faraday.stub(:get).with(key_url_with_tagoption).and_return(OpenStruct.new(:body => json, :headers => headers))
 
         service = Diplomat::Service.new(faraday)
-        options = { :tag => "sometag" }
-        s = service.get("toast", :first, options)
-        expect(s.Node).to eq("foo")
+        options = { :tag => 'sometag' }
+        s = service.get('toast', :first, options)
+        expect(s.Node).to eq('foo')
       end
 
-      it "all options" do
+      it 'all options' do
         json = JSON.generate(body)
 
-        faraday.stub(:get).with(key_url_with_alloptions).and_return(OpenStruct.new({ body: json, headers: headers }))
+        faraday.stub(:get).with(key_url_with_alloptions).and_return(OpenStruct.new(:body => json, :headers => headers))
 
         service = Diplomat::Service.new(faraday)
 
-        options = { :wait => "5m", :index => "3", :dc => 'somedc' }
-        s = service.get("toast", :first, options)
-        expect(s.Node).to eq("foo")
+        options = { :wait => '5m', :index => '3', :dc => 'somedc' }
+        s = service.get('toast', :first, options)
+        expect(s.Node).to eq('foo')
       end
     end
 
-    describe "Register service" do
-      let (:register_service_url) { '/v1/agent/service/register' }
-      let (:deregister_service_url) { '/v1/agent/service/deregister' }
+    describe 'Register service' do
+      let(:register_service_url) { '/v1/agent/service/register' }
+      let(:deregister_service_url) { '/v1/agent/service/deregister' }
 
-      let (:service_definition) do
+      let(:service_definition) do
         {
-          name: 'test_service_definition',
-          check: {
-            script: 'echo "true"',
-            interval: "1s"
+          :name => 'test_service_definition',
+          :check => {
+            :script => 'echo "true"',
+            :interval => '1s'
           }
         }
       end
 
       it 'can register a service' do
-
         json_request = JSON.dump(service_definition)
 
         expect(faraday).to receive(:put).with(register_service_url, json_request) do
-          OpenStruct.new({ body: '', status: 200 })
+          OpenStruct.new(:body => '', :status => 200)
         end
 
         service = Diplomat::Service.new(faraday)
@@ -198,14 +185,12 @@ describe Diplomat::Service do
       it 'can deregister a service' do
         url = "#{deregister_service_url}/#{service_definition[:name]}"
         expect(faraday).to receive(:get).with(url) do
-          OpenStruct.new({ body: '', status: 200 })
+          OpenStruct.new(:body => '', :status => 200)
         end
         service = Diplomat::Service.new(faraday)
         s = service.deregister(service_definition[:name])
         expect(s).to eq(true)
       end
     end
-
   end
-
 end

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -2,37 +2,36 @@ require 'spec_helper'
 require 'json'
 require 'base64'
 
-UUID = "fc5ca01a-c317-39ea-05e8-221da00d3a12"
+UUID = 'fc5ca01a-c317-39ea-05e8-221da00d3a12'
 
 describe Diplomat::Session do
   let(:faraday) { fake }
-  let(:single_object) { {"ID" => UUID}  }
+  let(:single_object) { { 'ID' => UUID } }
   let(:collection_object) { [single_object] }
   let(:single_json) { JSON.generate(single_object) }
-  let(:collection_json) {JSON.generate(collection_object)}
-  
-  context "session" do
+  let(:collection_json) { JSON.generate(collection_object) }
 
-    it "create" do
-      faraday.stub(:put).and_return(OpenStruct.new({ body: single_json }))
+  context 'session' do
+    it 'create' do
+      faraday.stub(:put).and_return(OpenStruct.new(:body => single_json))
       session = Diplomat::Session.new(faraday)
       expect(session.create({})).to eq(UUID)
     end
 
-    it "destroy" do
-      faraday.stub(:put).and_return(OpenStruct.new({ body: "true"}))
+    it 'destroy' do
+      faraday.stub(:put).and_return(OpenStruct.new(:body => 'true'))
       session = Diplomat::Session.new(faraday)
-      expect(session.destroy(UUID)).to eq("true")
+      expect(session.destroy(UUID)).to eq('true')
     end
 
-    it "list" do
-      faraday.stub(:get).and_return(OpenStruct.new({body: collection_json}))
+    it 'list' do
+      faraday.stub(:get).and_return(OpenStruct.new(:body => collection_json))
       sessions = Diplomat::Session.new(faraday)
       expect(sessions.list).to eql(collection_object)
     end
 
-    it "renew" do
-      faraday.stub(:put).and_return(OpenStruct.new({body: collection_json}))
+    it 'renew' do
+      faraday.stub(:put).and_return(OpenStruct.new(:body => collection_json))
       session = Diplomat::Session.new(faraday)
       expect(session.renew(UUID)).to eql(collection_object)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
-require "bundler/setup"
+require 'bundler/setup'
 Bundler.setup
 
 if ENV['CI'] == true
-  require "codeclimate-test-reporter"
+  require 'codeclimate-test-reporter'
   CodeClimate::TestReporter.start
 end
 


### PR DESCRIPTION
Summary:

- more ruby 1.8 support (noticed it was mentioned on the front page. I'm running Ruby 2.2.x but I switched the hash syntax to support 1.8)
- switched to Rspec 3 syntax
- some ternary bits
- linting

Hopefully comes in handy, thanks for looking at it!
