### PR TITLE
add timeout param to wait_to_acquire method

### DIFF
--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -23,13 +23,20 @@ module Diplomat
     # @param session [String] the session, generated from Diplomat::Session.create
     # @param value [String] the value for the key
     # @param check_interval [Integer] number of seconds to wait between retries
+    # @param timeout [Integer, nil] maxiumum number of seconds to wait for a lock
     # @return [Boolean] If the lock was acquired
-    def wait_to_acquire key, session, value=nil, check_interval=10
+    def wait_to_acquire key, session, value=nil, check_interval=10, timeout=nil
       acquired = false
-      while !acquired
-        acquired = self.acquire key, session, value
-        sleep(check_interval) if !acquired
-        return true if acquired
+      begin
+        Timeout.timeout(timeout) do
+          while !acquired
+            acquired = self.acquire key, session, value
+            sleep(check_interval) if !acquired
+            return true if acquired
+          end
+        end
+      rescue Timeout::Error
+        return false
       end
     end
 


### PR DESCRIPTION
Not sure what's the best approach for this but this allows to wait for a specified maximum amount of time to acquire a lock.