### PR TITLE
raw_values option to return true RAW values in recursive calls

### DIFF
--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -13,6 +13,7 @@ module Diplomat
     # @option options [String] :consistency The read consistency type
     # @option options [String] :dc Target datacenter
     # @option options [Boolean] :nil_values If to return keys/dirs with nil values
+    # @option options [Boolean] :raw_values If to return raw values
     # @param not_found [Symbol] behaviour if the key doesn't exist;
     #   :reject with exception, :return degenerate value, or :wait for it to appear
     # @param found [Symbol] behaviour if the key does exist;
@@ -45,6 +46,7 @@ module Diplomat
       url += dc(@options)
 
       return_nil_values = (@options and @options[:nil_values])
+      raw_values = (@options and @options[:raw_values])
 
       # 404s OK using this connection
       raw = @conn_no_err.get concat_url url
@@ -79,7 +81,7 @@ module Diplomat
         req.options.timeout = 86400
       end
       parse_body
-      return_value(return_nil_values)
+      return_value(return_nil_values, raw_values)
     end
 
     # Associate a value with a key

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -75,13 +75,14 @@ module Diplomat
     end
 
     # Get the key/value(s) from the raw output
-    def return_value(nil_values=false)
+    def return_value(nil_values=false, raw_values=false)
       if @raw.count == 1
         @value = @raw.first["Value"]
         @value = Base64.decode64(@value) unless @value.nil?
       else
         @value = @raw.reduce([]) do |acc, e|
           val = e["Value"].nil? ? nil : Base64.decode64(e["Value"])
+          val = JSON.parse("[#{val}]")[0] if raw_values and not val.nil?
           acc << {
             :key => e["Key"],
             :value => val


### PR DESCRIPTION
This is kind of last resort hack to get real raw values in recursive calls , similar to ?raw consul http kv api option for getting a raw value of a single key.
Problem is that in ruby after Base64.decode64(...) we do not get real raw value, we get a String,
for example if raw values was "x" we get "\"x\"" and if it was 1 we get "1"

Unfortunately i don't know a better workaround to get raw value than to wrap the value in "[]" and parse it as json.

Pls let me know if you are ok with these changes, and i'll proceed with unit tests
