### PR TITLE
Add Node!

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ Diplomat::Kv.get('foo/', recurse: true)
 # => [{:key=>"foo/a", :value=>"lorem"}, {:key=>"foo/b", :value=>"ipsum"}, {:key=>"foo/c", :value=>"dolor"}]
 ```
 
+### Nodes
+
+#### Getting
+
+Look up a node:
+
+```ruby
+foo_service = Diplomat::Node.get('foo')
+# => {"Node"=>{"Node"=>"foobar", "Address"=>"10.1.10.12"}, "Services"=>{"consul"=>{"ID"=>"consul", "Service"=>"consul", "Tags"=>nil, "Port"=>8300}, "redis"=>{"ID"=>"redis", "Service"=>"redis", "Tags"=>["v1"], "Port"=>8000}}}
+```
+
+Get all nodes:
+
+```ruby
+nodes = Diplomat::Node.get_all
+# => [#<OpenStruct Address="10.1.10.12", Node="foo">, #<OpenStruct Address="10.1.10.13", Node="bar">]
+```
+
 ### Services
 
 #### Getting

--- a/lib/diplomat.rb
+++ b/lib/diplomat.rb
@@ -21,7 +21,9 @@ module Diplomat
   self.root_path = File.expand_path "..", __FILE__
   self.lib_path = File.expand_path "../diplomat", __FILE__
 
-  require_libs "configuration", "rest_client", "kv", "datacenter", "service", "members", "nodes", "check", "health", "session", "lock", "error", "event"
+  require_libs "configuration", "rest_client", "kv", "datacenter", "service",
+    "members", "node", "nodes", "check", "health", "session", "lock", "error",
+    "event"
   self.configuration ||= Diplomat::Configuration.new
 
   class << self

--- a/lib/diplomat/node.rb
+++ b/lib/diplomat/node.rb
@@ -1,0 +1,41 @@
+require 'base64'
+require 'faraday'
+
+module Diplomat
+  class Node < Diplomat::RestClient
+
+    @access_methods = [ :get, :get_all ]
+
+    # Get a node by it's key
+    # @param key [String] the key
+    # @param options [Hash] :dc string for dc specific query
+    # @return [OpenStruct] all data associated with the node
+    def get key, options=nil
+
+      url = ["/v1/catalog/node/#{key}"]
+      url << use_named_parameter('dc', options[:dc]) if options and options[:dc]
+
+      # If the request fails, it's probably due to a bad path
+      # so return a PathNotFound error.
+      begin
+        ret = @conn.get concat_url url
+      rescue Faraday::ClientError
+        raise Diplomat::PathNotFound
+      end
+      return JSON.parse(ret.body)
+    end
+
+    # Get all the nodes
+    # @return [OpenStruct] the list of all nodes
+    def get_all
+      url = "/v1/catalog/nodes"
+      begin
+        ret = @conn.get url
+      rescue Faraday::ClientError
+        raise Diplomat::PathNotFound
+      end
+
+      return JSON.parse(ret.body).map { |service| OpenStruct.new service }
+    end
+  end
+end

--- a/lib/diplomat/nodes.rb
+++ b/lib/diplomat/nodes.rb
@@ -6,6 +6,7 @@ module Diplomat
     @access_methods = [ :get ]
 
     # Get all nodes
+    # @deprecated Please use Diplomat::Node instead.
     # @return [OpenStruct] all data associated with the nodes in catalog
     def get
       ret = @conn.get "/v1/catalog/nodes"

--- a/lib/diplomat/version.rb
+++ b/lib/diplomat/version.rb
@@ -1,3 +1,3 @@
 module Diplomat
-  VERSION = "0.14.1"
+  VERSION = "0.14.2"
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+require 'json'
+require 'base64'
+
+describe Diplomat::Node do
+
+  let(:faraday) { fake }
+
+  context "services" do
+    let(:key) { "foobar" }
+    let(:key_url) { "/v1/catalog/node/#{key}" }
+    let(:all_url) { "/v1/catalog/nodes" }
+    let(:body_all) {
+      [
+        {
+          "Address"     => "10.1.10.12",
+          "Node"        => "foo"
+        },
+        {
+
+          "Address"     => "10.1.10.13",
+          "Node"        => "bar",
+        }
+      ]
+    }
+    let(:body) {
+      {
+        "Node" => {
+          "Node" => "foobar",
+          "Address" => "10.1.10.12"
+        },
+        "Services" => {
+          "consul" => {
+            "ID" => "consul",
+            "Service" => "consul",
+            "Tags" => nil,
+            "Port" => 8300
+          },
+          "redis" => {
+            "ID" => "redis",
+            "Service" => "redis",
+            "Tags" => [
+              "v1"
+            ],
+            "Port" => 8000
+          }
+        }
+      }
+    }
+
+    describe "GET ALL" do
+      it "lists all the nodes" do
+        json = JSON.generate(body_all)
+
+        faraday.stub(:get).with(all_url).and_return(OpenStruct.new({ body: json }))
+
+        node = Diplomat::Node.new(faraday)
+        expect(node.get_all.size).to eq(2)
+      end
+    end
+
+    describe "GET" do
+      it "gets a node" do
+        json = JSON.generate(body)
+
+        faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json }))
+
+        node = Diplomat::Node.new(faraday)
+
+        cn = node.get("foobar")
+        expect(cn["Node"].length).to eq(2)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
# What's this PR do?

Adds `Diplomat::Node` with methods `get` and `get_all`.

# Motivation

The existing `Nodes` class doesn't allow getting a *specific* node and it's naming and use don't really conform to the standard set by `Diplomat::Node`. This ties that off!

# Notes

* I didn't do anything about deprecating `Nodes` but would be happy to.
* I'm not much of a rubyist and am unsure how to convert `get`'s response (which is a hash nested hashes!) in to an `OpenStruct` without relying on Ruby 2+'s `OpenStruct.from_json`.

Thanks for looking and let me know how I can help get this merged.