### PR TITLE
Add support for acls

### DIFF
--- a/lib/diplomat.rb
+++ b/lib/diplomat.rb
@@ -21,9 +21,9 @@ module Diplomat
   self.root_path = File.expand_path "..", __FILE__
   self.lib_path = File.expand_path "../diplomat", __FILE__
 
-  require_libs "configuration", "rest_client", "kv", "datacenter", "service",
-    "members", "node", "nodes", "check", "health", "session", "lock", "error",
-    "event", "acl"
+  require_libs "configuration", "rest_client", "api_options", "kv", "datacenter",
+    "service", "members", "node", "nodes", "check", "health", "session", "lock",
+    "error", "event", "acl"
   self.configuration ||= Diplomat::Configuration.new
 
   class << self

--- a/lib/diplomat.rb
+++ b/lib/diplomat.rb
@@ -23,7 +23,7 @@ module Diplomat
 
   require_libs "configuration", "rest_client", "kv", "datacenter", "service",
     "members", "node", "nodes", "check", "health", "session", "lock", "error",
-    "event"
+    "event", "acl"
   self.configuration ||= Diplomat::Configuration.new
 
   class << self

--- a/lib/diplomat/acl.rb
+++ b/lib/diplomat/acl.rb
@@ -1,0 +1,115 @@
+require 'base64'
+require 'faraday'
+
+module Diplomat
+  class Acl < Diplomat::RestClient
+    @access_methods = [ :list, :info, :create, :destroy, :update ]
+    attr_reader :id, :type, :acl
+
+
+    # Get Acl info by ID
+    # @param id [String] ID of the Acl to get
+    # @return [Hash]
+    def info id, options=nil, not_found=:reject, found=:return
+      @id = id
+      @options = options
+
+      url = ["/v1/acl/info/#{@id}"]
+      url += check_acl_token
+      url += use_consistency(@options)
+
+      raw = @conn_no_err.get concat_url url
+      if raw.status == 200 and raw.body
+        case found
+          when :reject
+            raise Diplomat::KeyAlreadyExists, key
+          when :return
+            @raw = raw
+            return parse_body
+        end
+      elsif raw.status == 200 and !raw.body
+        case not_found
+          when :reject
+            raise Diplomat::KeyNotFound, key
+          when :return
+            return nil
+        end
+      else
+        raise Diplomat::UnknownStatus, "status #{raw.status}"
+      end
+    end
+
+    # List all Acls
+    # @return [List] list of [Hash] of Acls
+    def list
+      url = ["/v1/acl/list"]
+      url += check_acl_token
+      raw = @conn_no_err.get concat_url url
+
+      if raw.status == 200
+        @raw = raw
+        return  parse_body
+      else
+        raise Diplomat::UnknownStatus, "status #{raw.status}"
+      end
+    end
+
+    # Update an Acl definition, create if not present
+    # @param ID [String] the ID, mandatory
+    # @param name [String] the name of the Acl
+    # @param type [String] acl type
+    # @option rules [String] rule definition in HCL
+    # @return [String] The ID of the Affected Acl
+    def update id, name=nil, type=nil, rules=nil
+      value = {}
+      value['Name'] = name unless name.nil?
+      value['ID'] = id unless id.nil?
+      value['Type'] = type unless name.nil?
+      value['Rules'] = rules unless rules.nil?
+      @raw = @conn.put do |req|
+        url = ["/v1/acl/create"]
+        url += check_acl_token
+        url += use_cas(@options)
+        req.url concat_url url
+        req.body = value.to_json
+      end
+      JSON.parse(@raw.body)['ID']
+    end
+
+    # Create an Acl definition, create if not present
+    # uses update without a given ID
+    # @param name [String] the name of the Acl
+    # @param type [String] acl type
+    # @option rules [String] rule definition in HCL
+    # @return [String] The ID of the Affected Acl
+    def create name=nil, type=nil, rules=nil
+      update(nil,name,type,rules)
+    end
+
+    # Destroy an ACl token by its id
+    # @param ID [String] the Acl ID
+    # @return [Bool]
+    def destroy id
+      @id = id
+      url = ["/v1/acl/destroy/#{@id}"]
+      url += check_acl_token
+      @raw = @conn.put concat_url url
+      @raw.body == "true"
+    end
+
+    private
+
+    def check_acl_token
+      use_named_parameter("token", Diplomat.configuration.acl_token)
+    end
+
+    def use_cas(options)
+      if options then use_named_parameter("cas", options[:cas]) else [] end
+    end
+
+    def use_consistency(options)
+      if options && options[:consistency] then ["#{options[:consistency]}"] else [] end
+    end
+
+  end
+end

--- a/lib/diplomat/acl.rb
+++ b/lib/diplomat/acl.rb
@@ -3,9 +3,11 @@ require 'faraday'
 
 module Diplomat
   class Acl < Diplomat::RestClient
+
+    include ApiOptions
+
     @access_methods = [ :list, :info, :create, :destroy, :update ]
     attr_reader :id, :type, :acl
-
 
     # Get Acl info by ID
     # @param id [String] ID of the Acl to get
@@ -48,7 +50,7 @@ module Diplomat
 
       if raw.status == 200
         @raw = raw
-        return  parse_body
+        return parse_body
       else
         raise Diplomat::UnknownStatus, "status #{raw.status}"
       end
@@ -94,20 +96,5 @@ module Diplomat
       @raw = @conn.put concat_url url
       @raw.body == "true"
     end
-
-    private
-
-    def check_acl_token
-      use_named_parameter("token", Diplomat.configuration.acl_token)
-    end
-
-    def use_cas(options)
-      if options then use_named_parameter("cas", options[:cas]) else [] end
-    end
-
-    def use_consistency(options)
-      if options && options[:consistency] then ["#{options[:consistency]}"] else [] end
-    end
-
   end
 end

--- a/lib/diplomat/api_options.rb
+++ b/lib/diplomat/api_options.rb
@@ -1,0 +1,15 @@
+module Diplomat
+  module ApiOptions
+    def check_acl_token
+      use_named_parameter("token", Diplomat.configuration.acl_token)
+    end
+
+    def use_cas(options)
+      if options then use_named_parameter("cas", options[:cas]) else [] end
+    end
+
+    def use_consistency(options)
+      if options && options[:consistency] then ["#{options[:consistency]}"] else [] end
+    end
+  end
+end

--- a/lib/diplomat/error.rb
+++ b/lib/diplomat/error.rb
@@ -2,7 +2,10 @@ module Diplomat
   class KeyNotFound < StandardError; end
   class PathNotFound < StandardError; end
   class KeyAlreadyExists < StandardError; end
+  class AclNotFound < StandardError; end
+  class AclAlreadyExists < StandardError; end
   class EventNotFound < StandardError; end
   class EventAlreadyExists < StandardError; end
   class UnknownStatus < StandardError; end
+  class IdParameterRequired < StandardError; end
 end

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -3,6 +3,9 @@ require 'faraday'
 
 module Diplomat
   class Kv < Diplomat::RestClient
+
+    include ApiOptions
+
     @access_methods = [ :get, :put, :delete ]
     attr_reader :key, :value, :raw
 
@@ -125,18 +128,6 @@ module Diplomat
     end
 
     private
-
-    def check_acl_token
-      use_named_parameter("token", Diplomat.configuration.acl_token)
-    end
-
-    def use_cas(options)
-      if options then use_named_parameter("cas", options[:cas]) else [] end
-    end
-
-    def use_consistency(options)
-      if options && options[:consistency] then ["#{options[:consistency]}"] else [] end
-    end
 
     def recurse_get(options)
       if options && options[:recurse] == true then ['recurse'] else [] end

--- a/lib/diplomat/version.rb
+++ b/lib/diplomat/version.rb
@@ -1,3 +1,3 @@
 module Diplomat
-  VERSION = "0.14.2"
+  VERSION = "0.15.0"
 end

--- a/spec/acl_spec.rb
+++ b/spec/acl_spec.rb
@@ -80,7 +80,7 @@ describe Diplomat::Acl do
         json = JSON.generate(list_body)
 
         url = key_url + '/list'
-        faraday.stub(:get).with(url).and_return(OpenStruct.new({ body: json, status: 200}))
+        expect(faraday).to receive(:get).with(/#{url}/).and_return(OpenStruct.new({ body: json, status: 200}))
 
         acl = Diplomat::Acl.new(faraday)
         list = acl.list

--- a/spec/acl_spec.rb
+++ b/spec/acl_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+require 'json'
+require 'base64'
+
+describe Diplomat::Acl do
+
+  let(:faraday) { fake }
+
+  context "acls" do
+    let(:key_url) { "/v1/acl" }
+
+    let(:id) { "8f246b77-f3e1-ff88-5b48-8ec93abf3e05" }
+
+    let(:info_body) {
+      [
+        {
+          "CreateIndex" => 3,
+          "ModifyIndex" => 3,
+          "ID" => id,
+          "Name" => "Client Token",
+          "Type" => "client",
+          "Rules" => {
+            "service" => {
+              "" => {
+                "policy" => "write"
+              }
+            }
+          }
+        }
+      ]
+    }
+    let(:list_body) {
+      [
+        info_body,
+        {
+          "CreateIndex" => 3,
+          "ModifyIndex" => 3,
+          "ID" => 'another-id',
+          "Name" => "Client Token bis",
+          "Type" => "client",
+          "Rules" => {
+            "service" => {
+              "" => {
+                "policy" => "write"
+              }
+            }
+          }
+        }
+      ]
+    }
+
+    describe "info" do
+      it "returns existing acl" do
+        json = JSON.generate(info_body)
+
+        url = key_url + '/info/' + id
+        expect(faraday).to receive(:get).with(/#{url}/).and_return(OpenStruct.new({ body: json, status: 200}))
+
+        acl = Diplomat::Acl.new(faraday)
+        info = acl.info(id)
+
+        expect(info.size).to eq(1)
+        expect(info.first["Name"]).to eq("Client Token")
+      end
+
+      it "returns does not return acl" do
+        json = nil
+
+        url = key_url + '/info/' + 'none'
+        expect(faraday).to receive(:get).with(/#{url}/).and_return(OpenStruct.new({ body: json, status: 200}))
+
+        acl = Diplomat::Acl.new(faraday)
+
+        expect { acl.info('none') }.to raise_error(Diplomat::AclNotFound)
+      end
+    end
+
+    describe "list" do
+      it "return all acls" do
+        json = JSON.generate(list_body)
+
+        url = key_url + '/list'
+        faraday.stub(:get).with(url).and_return(OpenStruct.new({ body: json, status: 200}))
+
+        acl = Diplomat::Acl.new(faraday)
+        list = acl.list
+
+        expect(list.size).to eq(2)
+      end
+    end
+
+    describe "update" do
+      it "return the ID" do
+        json = JSON.generate(info_body.first)
+
+        url = key_url + '/update'
+        req = fake
+        expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new({ body: json, status: 200}))
+        expect(req).to receive(:url).with(/#{url}/)
+
+        acl = Diplomat::Acl.new(faraday)
+        response = acl.update(info_body.first)
+
+        expect(response['ID']).to eq(info_body.first['ID'])
+      end
+
+      it "fails if no ID is provided " do
+        acl = Diplomat::Acl.new(faraday)
+        expect{ acl.update({Name: 'test'}) }.to raise_error(Diplomat::IdParameterRequired)
+
+      end
+    end
+
+    describe "create" do
+      it "return the ID" do
+        json = JSON.generate(info_body.first)
+
+        url = key_url + '/create'
+        req = fake
+        expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new({ body: json, status: 200}))
+        expect(req).to receive(:url).with(/#{url}/)
+
+        acl = Diplomat::Acl.new(faraday)
+        response = acl.create(info_body.first)
+
+        expect(response['ID']).to eq(info_body.first['ID'])
+      end
+    end
+
+    describe "destroy" do
+      it "return the ID" do
+
+        url = key_url + '/destroy/' + id
+        expect(faraday).to receive(:put).with(/#{url}/).and_return(OpenStruct.new({ body: 'true', status: 200}))
+        acl = Diplomat::Acl.new(faraday)
+        response = acl.destroy(id)
+
+        expect(response).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch adds support for consul acl. It allows to create/update/destroy/list and get info on acls.

It also factorize the common options used.