### PR TITLE
Service class: get_all services by datacenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ services = Diplomat::Service.get_all
 # => #<OpenStruct consul=[], foo=[], bar=[]>
 ```
 
+If you wish to list all the services for a specific datacenter:
+
+```ruby
+services = Diplomat::Service.get_all({ :dc => 'My_Datacenter' })
+# => #<OpenStruct consul=[], foo=[], bar=[]>
+```
+
 ### Datacenters
 
 Getting a list of datacenters is quite simple and gives you the option to extract all services out of

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -42,11 +42,13 @@ module Diplomat
     end
 
     # Get all the services
+    # @param options [Hash] :dc Consul datacenter to query
     # @return [OpenStruct] the list of all services
-    def get_all
-      url = "/v1/catalog/services"
+    def get_all options=nil
+      url = ["/v1/catalog/services"]
+      url << use_named_parameter('dc', options[:dc]) if options and options[:dc]
       begin
-        ret = @conn.get url
+        ret = @conn.get concat_url url
       rescue Faraday::ClientError
         raise Diplomat::PathNotFound
       end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -14,6 +14,7 @@ describe Diplomat::Service do
     let(:key_url_with_waitoption) { "/v1/catalog/service/#{key}?wait=6s" }
     let(:key_url_with_datacenteroption) { "/v1/catalog/service/#{key}?dc=somedc" }
     let(:key_url_with_tagoption) { "/v1/catalog/service/#{key}?tag=sometag" }
+    let(:services_url_with_datacenteroption) { "/v1/catalog/services?dc=somedc" }
     let(:body) {
       [
         {
@@ -175,7 +176,7 @@ describe Diplomat::Service do
     end
 
     describe "GET ALL" do
-      it "lists all the services" do
+      it "lists all the services for the default datacenter" do
         json = JSON.generate(body_all)
 
         faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
@@ -185,6 +186,18 @@ describe Diplomat::Service do
         expect(service.get_all.service2).to be_an(Array)
         expect(service.get_all.service1.first).to eq("tag one")
         expect(service.get_all.service2.first).to eq("tag four")
+      end
+      it "lists all the services for the specified datacenter" do
+        json = JSON.generate(body_all)
+
+        faraday.stub(:get).with(services_url_with_datacenteroption).and_return(OpenStruct.new({ body: json }))
+
+        options = { :dc => "somedc" }
+        service = Diplomat::Service.new(faraday)
+        expect(service.get_all(options).service1).to be_an(Array)
+        expect(service.get_all(options).service2).to be_an(Array)
+        expect(service.get_all(options).service1.first).to eq("tag one")
+        expect(service.get_all(options).service2.first).to eq("tag four")
       end
     end
 


### PR DESCRIPTION
# What's this PR do?
Add support for querying all services by datacenter

# Motivation
The existing `Service#get_all` method doesn't allow specifying a datacenter when querying, and will only return services for the default datacenter of the agent serving the API. This is especially useful when accessing a WAN consul cluster via another cluster, e.g. when the former is inaccessible due to firewall rules.

# What's included?
Included are specs, the function change and documentation changes (rdoc and README).

Thanks for taking a look, please let me know if this needs any work.