### PR TITLE
Add .respond_to? and .respond_to_missing? to Diplomat::RestClient

### DIFF
--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -43,7 +43,17 @@ module Diplomat
       # @param *args Arguments list
       # @return [Boolean]
       def method_missing(meth_id, *args)
-        access_method?(meth_id) ? new.send(meth_id, *args) : super
+        if access_method?(meth_id)
+          new.send(meth_id, *args)
+        else
+
+          # See https://bugs.ruby-lang.org/issues/10969
+          begin
+            super
+          rescue NameError => err
+            raise NoMethodError, err
+          end
+        end
       end
 
       # Make `respond_to?` aware of method short-cuts.

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -46,6 +46,22 @@ module Diplomat
         access_method?(meth_id) ? new.send(meth_id, *args) : super
       end
 
+      # Make `respond_to?` aware of method short-cuts.
+      #
+      # @param meth_id [Symbol] the tested method
+      # @oaram with_private if private methods should be tested too
+      def respond_to?(meth_id, with_private = false)
+        access_method?(meth_id) || super
+      end
+
+      # Make `respond_to_missing` aware of method short-cuts. This is needed for
+      # {#method} to work on these, which is helpful for testing purposes.
+      #
+      # @param meth_id [Symbol] the tested method
+      # @oaram with_private if private methods should be tested too
+      def respond_to_missing?(meth_id, with_private = false)
+        access_method?(meth_id) || super
+      end
     end
 
     private

--- a/spec/rest_client_spec.rb
+++ b/spec/rest_client_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe Diplomat::RestClient do
+
+  let(:klass) do
+    Class.new Diplomat::RestClient do
+      @access_methods = [ :accessible ]
+
+      def accessible(*args)
+        args
+      end
+    end
+  end
+
+  context '.method_missing' do
+    it 'calls the accessible method on a new instance' do
+      dummy = double 'Dummy RestClient'
+
+      expect(klass).to receive(:new).and_return dummy
+      expect(dummy).to receive(:accessible).with(1, 2, 3).and_return nil
+
+      klass.method_missing :accessible, 1, 2, 3
+    end
+
+    it 'falls back to super' do
+      expect(Diplomat::RestClient.superclass).to receive(:method_missing).at_least(:once).and_call_original
+      expect{ klass.method_missing :does_not_exist }.to raise_error NoMethodError
+    end
+  end
+
+  context '.respond_to?' do
+    it 'returns true' do
+      expect(klass.respond_to? :accessible).to eq true
+    end
+
+    it 'falls back to super' do
+      expect(Diplomat::RestClient.superclass).to receive(:respond_to?).at_least(:once).and_call_original
+      expect(klass.respond_to? :hash).to eq true
+    end
+  end
+
+  context '.respond_to_missing?' do
+    it 'returns true' do
+      expect(klass.respond_to_missing? :accessible).to eq true
+    end
+
+    it 'falls back to super' do
+      expect(Diplomat::RestClient.superclass).to receive(:respond_to_missing?).and_call_original
+
+      klass.respond_to_missing? :hash
+    end
+
+    it 'works with Object#method' do
+      expect(klass.method :accessible).to be_a Method
+      expect(klass.method(:accessible).call 1, 2).to eq [1, 2]
+    end
+
+    it 'lets RSpec mock the accessible method' do
+      expect(klass).to receive(:accessible).and_call_original
+      expect(klass.accessible 1, 2).to eq [1, 2]
+    end
+  end
+end


### PR DESCRIPTION
While I was testing a tool which uses Diplomat, I noticed that I was not able to mock the 'accessible methods'.

For this to work, `#respond_to_missing?` is needed to return `true` for methods 'created' with `#method_missing`. Added it (and `#respond_to?`) to `Diplomat::RestClient` as class methods.
