### PR TITLE
Improve acl info method when the acl does not exist

### DIFF
--- a/lib/diplomat/acl.rb
+++ b/lib/diplomat/acl.rb
@@ -21,7 +21,7 @@ module Diplomat
       url += use_consistency(@options)
 
       raw = @conn_no_err.get concat_url url
-      if raw.status == 200 and raw.body
+      if raw.status == 200 and raw.body != "null"
         case found
           when :reject
             raise Diplomat::AclAlreadyExists, @id
@@ -29,7 +29,7 @@ module Diplomat
             @raw = raw
             return parse_body
         end
-      elsif raw.status == 200 and !raw.body
+      elsif raw.status == 200 and raw.body == "null"
         case not_found
           when :reject
             raise Diplomat::AclNotFound, @id

--- a/spec/acl_spec.rb
+++ b/spec/acl_spec.rb
@@ -64,7 +64,7 @@ describe Diplomat::Acl do
       end
 
       it "returns does not return acl" do
-        json = nil
+        json = 'null'
 
         url = key_url + '/info/' + 'none'
         expect(faraday).to receive(:get).with(/#{url}/).and_return(OpenStruct.new({ body: json, status: 200}))


### PR DESCRIPTION
According to https://www.consul.io/docs/agent/http/acl.html, when the
acl does not exist, return value is "null" instead of nothing.

Fixes #71