### PR TITLE
allow for a datacenter when getting all nodes

### DIFF
--- a/lib/diplomat/node.rb
+++ b/lib/diplomat/node.rb
@@ -27,10 +27,11 @@ module Diplomat
 
     # Get all the nodes
     # @return [OpenStruct] the list of all nodes
-    def get_all
-      url = "/v1/catalog/nodes"
+    def get_all options=nil
+      url = ["/v1/catalog/nodes"]
+      url << use_named_parameter('dc', options[:dc]) if options and options[:dc]
       begin
-        ret = @conn.get url
+        ret = @conn.get concat_url url
       rescue Faraday::ClientError
         raise Diplomat::PathNotFound
       end

--- a/lib/diplomat/node.rb
+++ b/lib/diplomat/node.rb
@@ -27,11 +27,10 @@ module Diplomat
 
     # Get all the nodes
     # @return [OpenStruct] the list of all nodes
-    def get_all options=nil
-      url = ["/v1/catalog/nodes"]
-      url << use_named_parameter('dc', options[:dc]) if options and options[:dc]
+    def get_all
+      url = "/v1/catalog/nodes"
       begin
-        ret = @conn.get concat_url url
+        ret = @conn.get url
       rescue Faraday::ClientError
         raise Diplomat::PathNotFound
       end

--- a/lib/diplomat/nodes.rb
+++ b/lib/diplomat/nodes.rb
@@ -12,5 +12,16 @@ module Diplomat
       ret = @conn.get "/v1/catalog/nodes"
       return JSON.parse(ret.body)
     end
+    
+    def get_all options=nil
+      url = ["/v1/catalog/nodes"]
+      url << use_named_parameter('dc', options[:dc]) if options and options[:dc]
+      begin
+        ret = @conn.get concat_url url
+      rescue Faraday::ClientError
+        raise Diplomat::PathNotFound
+      end
+      return JSON.parse(ret.body).map { |service| OpenStruct.new service }
+    end 
   end
 end

--- a/lib/diplomat/nodes.rb
+++ b/lib/diplomat/nodes.rb
@@ -3,7 +3,7 @@ require 'faraday'
 
 module Diplomat
   class Nodes < Diplomat::RestClient
-    @access_methods = [ :get ]
+    @access_methods = [ :get, :get_all ]
 
     # Get all nodes
     # @deprecated Please use Diplomat::Node instead.

--- a/spec/nodes_spec.rb
+++ b/spec/nodes_spec.rb
@@ -5,6 +5,17 @@ require 'base64'
 describe Diplomat::Nodes do
 
   let(:faraday) { fake }
+  let(:datacenter) { "us-west2" }
+  let(:datacenter_body_all) {
+      [
+        {
+          "Address"     => "10.1.10.12",
+          "Node"        => "foo",
+          "Datacenter"  => "us-west2",
+        },
+      ]
+   }
+  let(:all_datacenter_url) { "/v1/catalog/nodes?dc=#{datacenter}" }
 
   context "nodes" do
 
@@ -27,7 +38,14 @@ describe Diplomat::Nodes do
       expect(nodes.get.first["Node"]).to eq("baz")
       expect(nodes.get.first["Address"]).to eq("10.1.10.11")
     end
+    it "GET ALL" do
+        json = JSON.generate(datacenter_body_all)
+        faraday.stub(:get).with(all_datacenter_url).and_return(OpenStruct.new({ body: json }))
 
+        nodes = Diplomat::Nodes.new(faraday)
+        options = { dc: "us-west2" } 
+        expect(nodes.get_all(options).size).to eq(1)
+    end
   end
 
 end


### PR DESCRIPTION
i noticed that i could curl and get all nodes, but not with your api. this uses the same convention you have for getting all services.

https://www.consul.io/docs/agent/http/catalog.html#catalog_nodes