### PR TITLE
Remove restriction on json version

### DIFF
--- a/diplomat.gemspec
+++ b/diplomat.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new "diplomat", Diplomat::VERSION do |spec|
   spec.add_development_dependency "gem-release", "~> 0.7"
   spec.add_development_dependency "cucumber", "~> 2.0"
 
-  spec.add_runtime_dependency "json", "~> 1.8"
+  spec.add_runtime_dependency "json"
   spec.add_runtime_dependency "faraday", "~> 0.9"
 end


### PR DESCRIPTION
@johnhamelink I noticed that you restricted the json version in 5c92c0bbffad7b1096644ea9eab5dc9bd2349d89. Could that restriction be lifted? The reason I ask is because this restriction conflicts with a lot of other gems.

```
  spec.add_runtime_dependency "json", "~> 1.8"
```

https://github.com/WeAreFarmGeek/diplomat/blob/4152f810014fcbc02e92fe566ad6fa32d95495e4/diplomat.gemspec#L22