### PR TITLE
Adding ability to register/deregister nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ nodes = Diplomat::Node.get_all
 # => [#<OpenStruct Address="10.1.10.12", Node="foo">, #<OpenStruct Address="10.1.10.13", Node="bar">]
 ```
 
+Register a node:
+
+```ruby
+Diplomat::Node.register({ :Node => "app1", :Address => "10.0.0.2" })
+# => true
+```
+
+De-register a node:
+
+```ruby
+Diplomat::Node.deregister({ :Node => "app1", :Address => "10.0.0.2" })
+# => true
+```
+
 ### Services
 
 #### Getting

--- a/lib/diplomat/node.rb
+++ b/lib/diplomat/node.rb
@@ -4,7 +4,7 @@ require 'faraday'
 module Diplomat
   class Node < Diplomat::RestClient
 
-    @access_methods = [ :get, :get_all ]
+    @access_methods = [ :get, :get_all, :register, :deregister ]
 
     # Get a node by it's key
     # @param key [String] the key
@@ -36,6 +36,24 @@ module Diplomat
       end
 
       return JSON.parse(ret.body).map { |service| OpenStruct.new service }
+    end
+
+    # Register a node
+    # @param definition [Hash] Hash containing definition of a node to register
+    # @return [Boolean]
+    def register(definition, path='/v1/catalog/register')
+      register = @conn.put path, JSON.dump(definition)
+
+      return register.status == 200
+    end
+
+    # De-register a node (and all associated services and checks)
+    # @param definition [Hash] Hash containing definition of a node to de-register
+    # @return [Boolean]
+    def deregister(definition, path="/v1/catalog/deregister")
+      deregister = @conn.put path, JSON.dump(definition)
+
+      return deregister.status == 200
     end
   end
 end

--- a/lib/diplomat/version.rb
+++ b/lib/diplomat/version.rb
@@ -1,3 +1,3 @@
 module Diplomat
-  VERSION = "0.17.0"
+  VERSION = "0.17.1"
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -6,6 +6,46 @@ describe Diplomat::Node do
 
   let(:faraday) { fake }
 
+  context "nodes" do
+    let(:node_definition) {
+      {
+        "Node" => "foobar",
+        "Address" => "192.168.10.10"
+      }
+    }
+
+    describe "#register" do
+      let(:path) { "/v1/catalog/register" }
+
+      it "registers a node" do
+        json = JSON.generate(node_definition)
+
+        faraday.stub(:put).with(path, json).and_return( OpenStruct.new({ body: "", status: 200 }) )
+
+        node = Diplomat::Node.new(faraday)
+
+        n = node.register(node_definition)
+        expect(n).to eq(true)
+      end
+    end
+
+    describe "#deregister" do
+      let(:path) { "/v1/catalog/deregister" }
+
+      it "de-registers a node" do
+        json = JSON.generate(node_definition)
+
+        faraday.stub(:put).with(path, json).and_return( OpenStruct.new({ body: "", status: 200 }) )
+
+        node = Diplomat::Node.new(faraday)
+
+        n = node.deregister(node_definition)
+        expect(n).to eq(true)
+      end
+    end
+
+  end
+
   context "services" do
     let(:key) { "foobar" }
     let(:key_url) { "/v1/catalog/node/#{key}" }


### PR DESCRIPTION
###### What's this PR do?
Adds missing `Diplomat::Nodes#register` and `Diplomat::Nodes#deregister` methods.

###### Notes
* [`/v1/catalog/register` Endpoint](https://www.consul.io/docs/agent/http/catalog.html#catalog_register)
* [`/v1/catalog/deregister` Endpoint](https://www.consul.io/docs/agent/http/catalog.html#catalog_deregister)