### PR TITLE
Add Diplomat::Maintenance class with #enable and #enabled?

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,21 @@ end
 events.each{ |e| puts e }
 ```
 
+### Maintenance mode
+
+Enable maintenance mode on a host, with optional reason and DC (requires access to local agent)
+
+```ruby
+Diplomat::Maintenance.enable(true, 'doing stuff', :dc => 'abc')
+```
+
+Determine if a host has maintenance mode enabled
+
+```ruby
+Diplomat::Maintenance.enabled?('foobar')
+# => true
+```
+
 ### Custom configuration
 
 You can create a custom configuration using the following syntax:

--- a/README.md
+++ b/README.md
@@ -252,8 +252,8 @@ Diplomat::Maintenance.enable(true, 'doing stuff', :dc => 'abc')
 Determine if a host has maintenance mode enabled
 
 ```ruby
-Diplomat::Maintenance.enabled?('foobar')
-# => true
+Diplomat::Maintenance.enabled('foobar')
+# => { :enabled => true, :reason => 'doing stuff' }
 ```
 
 ### Custom configuration

--- a/lib/diplomat.rb
+++ b/lib/diplomat.rb
@@ -23,7 +23,7 @@ module Diplomat
 
   require_libs "configuration", "rest_client", "api_options", "kv", "datacenter",
     "service", "members", "node", "nodes", "check", "health", "session", "lock",
-    "error", "event", "acl"
+    "error", "event", "acl", "maintenance"
   self.configuration ||= Diplomat::Configuration.new
 
   class << self

--- a/lib/diplomat/maintenance.rb
+++ b/lib/diplomat/maintenance.rb
@@ -1,0 +1,41 @@
+require 'base64'
+require 'faraday'
+
+module Diplomat
+  class Maintenance < Diplomat::RestClient
+    @access_methods = [ :enabled?, :enable]
+
+    # Get the maintenance state of a host
+    # @param n [String] the node
+    # @param options [Hash] :dc string for dc specific query
+    # @return true if maintenance mode is enabled
+    def enabled? n, options=nil
+      health = Diplomat::Health.new(@conn)
+      health.node(n, options).
+        select { |check| check['CheckID'] == '_node_maintenance' }.size > 0
+    end
+
+    # Enable or disable maintenance mode.  This endpoint only works
+    # on the local agent.
+    # @param enable enable or disable maintenance mode
+    # @param reason [String] the reason for enabling maintenance mode
+    # @param options [Hash] :dc string for dc specific query
+    # @return true if call is successful
+    def enable enable=true, reason=nil, options=nil
+      raw = @conn.put do |req|
+        url = ["/v1/agent/maintenance"]
+        url << use_named_parameter('enable', enable.to_s)
+        url << use_named_parameter('reason', reason) unless reason.nil?
+        url << use_named_parameter('dc', options[:dc]) if options and options[:dc]
+        req.url concat_url url
+      end
+
+      if raw.status == 200
+        @raw = raw
+        return true
+      else
+        raise Diplomat::UnknownStatus, "status #{raw.status}"
+      end
+    end
+  end
+end

--- a/spec/maintenance_spec.rb
+++ b/spec/maintenance_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+require 'json'
+require 'base64'
+
+describe Diplomat::Maintenance do
+
+  let(:faraday) { fake }
+  let(:req) { fake }
+
+  context "enabled?" do
+    it "enabled" do
+      json = <<EOF
+      [
+            {
+                "Node": "foobar",
+                "CheckID": "serfHealth",
+                "Name": "Serf Health Status",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "",
+                "ServiceID": "",
+                "ServiceName": ""
+            },
+            {
+                "Node": "foobar",
+                "CheckID": "_node_maintenance",
+                "Name": "Node Maintenance Mode",
+                "Status": "critical",
+                "Notes": "foo",
+                "Output": "",
+                "ServiceID": "",
+                "ServiceName": "",
+                "CreateIndex": 135459,
+                "ModifyIndex": 135459
+            }
+        ]
+EOF
+      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+      maintenance = Diplomat::Maintenance.new(faraday)
+      expect(maintenance.enabled?("foobar")).to eq(true)
+    end
+
+    it "disabled" do
+      json = <<EOF
+      [
+            {
+                "Node": "foobar",
+                "CheckID": "serfHealth",
+                "Name": "Serf Health Status",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "",
+                "ServiceID": "",
+                "ServiceName": ""
+            }
+        ]
+EOF
+      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+      maintenance = Diplomat::Maintenance.new(faraday)
+      expect(maintenance.enabled?("foobar")).to eq(false)
+    end
+  end
+
+  context "enable" do
+    before do
+      expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new({ body: "", status: 200}))
+    end
+
+    it "enables" do
+      maintenance = Diplomat::Maintenance.new(faraday)
+      expect(req).to receive(:url).with('/v1/agent/maintenance?enable=true')
+      expect(maintenance.enable(true)).to eq(true)
+    end
+
+    it "disables" do
+      maintenance = Diplomat::Maintenance.new(faraday)
+      expect(req).to receive(:url).with('/v1/agent/maintenance?enable=false')
+      expect(maintenance.enable(false)).to eq(true)
+    end
+
+    it "with reason" do
+      maintenance = Diplomat::Maintenance.new(faraday)
+      expect(req).to receive(:url).with('/v1/agent/maintenance?enable=true&reason=foobar')
+      expect(maintenance.enable(true, 'foobar')).to eq(true)
+    end
+
+    it "with dc" do
+      maintenance = Diplomat::Maintenance.new(faraday)
+      expect(req).to receive(:url).with('/v1/agent/maintenance?enable=true&reason=foobar&dc=abc')
+      expect(maintenance.enable(true, 'foobar', {:dc => 'abc'})).to eq(true)
+    end
+  end
+
+  context "enable raises errors" do
+    it "throw error unless 200" do
+      expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new({ body: "", status: 500}))
+      maintenance = Diplomat::Maintenance.new(faraday)
+      expect(req).to receive(:url).with('/v1/agent/maintenance?enable=true')
+      expect{ maintenance.enable(true) }.to raise_error(Diplomat::UnknownStatus, 'status 500')
+    end
+  end
+end
+

--- a/spec/maintenance_spec.rb
+++ b/spec/maintenance_spec.rb
@@ -7,7 +7,7 @@ describe Diplomat::Maintenance do
   let(:faraday) { fake }
   let(:req) { fake }
 
-  context "enabled?" do
+  context "enabled" do
     it "enabled" do
       json = <<EOF
       [
@@ -26,7 +26,7 @@ describe Diplomat::Maintenance do
                 "CheckID": "_node_maintenance",
                 "Name": "Node Maintenance Mode",
                 "Status": "critical",
-                "Notes": "foo",
+                "Notes": "foo bar",
                 "Output": "",
                 "ServiceID": "",
                 "ServiceName": "",
@@ -37,7 +37,7 @@ describe Diplomat::Maintenance do
 EOF
       faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
       maintenance = Diplomat::Maintenance.new(faraday)
-      expect(maintenance.enabled?("foobar")).to eq(true)
+      expect(maintenance.enabled("foobar")).to eq({:enabled => true, :reason => 'foo bar'})
     end
 
     it "disabled" do
@@ -57,7 +57,7 @@ EOF
 EOF
       faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
       maintenance = Diplomat::Maintenance.new(faraday)
-      expect(maintenance.enabled?("foobar")).to eq(false)
+      expect(maintenance.enabled("foobar")).to eq({:enabled => false, :reason => nil})
     end
   end
 


### PR DESCRIPTION
Adds wrappers around the `/v1/agent/maintenance` endpoint and a helper method `#enabled` to determine if a host is already in maintenance mode.