### PR TITLE
Add dc param support to Diplomat::Node.get_all

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,13 @@ nodes = Diplomat::Node.get_all
 # => [#<OpenStruct Address="10.1.10.12", Node="foo">, #<OpenStruct Address="10.1.10.13", Node="bar">]
 ```
 
+Get all nodes for a particular datacenter
+
+```ruby
+nodes = Diplomat::Node.get_all({ :dc => 'My_Datacenter' })
+# => [#<OpenStruct Address="10.1.10.12", Node="foo">, #<OpenStruct Address="10.1.10.13", Node="bar">]
+```
+
 Register a node:
 
 ```ruby

--- a/lib/diplomat/node.rb
+++ b/lib/diplomat/node.rb
@@ -29,11 +29,13 @@ module Diplomat
     end
 
     # Get all the nodes
+    # @param options [Hash] :dc string for dc specific query
     # @return [OpenStruct] the list of all nodes
-    def get_all
-      url = "/v1/catalog/nodes"
+    def get_all options=nil
+      url = ["/v1/catalog/nodes"]
+      url << use_named_parameter('dc', options[:dc]) if options and options[:dc]
       begin
-        ret = @conn.get url
+        ret = @conn.get concat_url url
       rescue Faraday::ClientError
         raise Diplomat::PathNotFound
       end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -87,6 +87,15 @@ describe Diplomat::Node do
         }
       }
     }
+    let(:all_with_dc_url) { "/v1/catalog/nodes?dc=dc1" }
+    let(:body_all_with_dc) {
+      [
+        {
+          "Address"     => "10.1.10.14",
+          "Node"        => "foo"
+        },
+      ]
+    }
 
     describe "GET ALL" do
       it "lists all the nodes" do
@@ -96,6 +105,15 @@ describe Diplomat::Node do
 
         node = Diplomat::Node.new(faraday)
         expect(node.get_all.size).to eq(2)
+      end
+
+      it "lists all the nodes" do
+        json = JSON.generate(body_all_with_dc)
+
+        faraday.stub(:get).with(all_with_dc_url).and_return(OpenStruct.new({ body: json }))
+
+        node = Diplomat::Node.new(faraday)
+        expect(node.get_all({ :dc => 'dc1' }).size).to eq(1)
       end
     end
 


### PR DESCRIPTION
`/v1/catalog/nodes` allows a `dc` param, this PR adds support for that via options.