### PR TITLE
include error message in exception

### DIFF
--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -27,8 +27,8 @@ module Diplomat
       # so return a PathNotFound error.
       begin
         ret = @conn.get concat_url url
-      rescue Faraday::ClientError
-        raise Diplomat::PathNotFound
+      rescue Faraday::ClientError => e
+        raise Diplomat::PathNotFound, e
       end
 
       if meta and ret.headers


### PR DESCRIPTION
e.g. when you get connection refused it is confusing, as you just get

    Diplomat::PathNotFound: Diplomat::PathNotFound

with this change you get

    Diplomat::PathNotFound: Failed to open TCP connection to 192.168.174.132:8501 (Connection refused - connect(2) for "192.168.174.132" port 8501)