### PR TITLE
Don't strip away Consul metadata if we return a single value

### DIFF
--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -90,10 +90,6 @@ module Diplomat
       @value = decode_values
       if @value.first.is_a? String
         return @value
-      elsif @value.count == 1
-        @value = @value.first["Value"]
-        @value = transformation.call(@value) if transformation and not @value.nil?
-        return @value
       else
         @value = @value.map do |el|
           el["Value"] = transformation.call(el["Value"]) if transformation and not el["Value"].nil?

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -137,7 +137,10 @@ describe Diplomat::Kv do
           }])
           faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get(key)).to eq("toast")
+          expect(kv.get(key)).to eq([{
+            key: key,
+            value: 'toast'
+            }])
         end
         it "GET with consistency param" do
           options = {:consistency => "consistent"}
@@ -148,7 +151,10 @@ describe Diplomat::Kv do
           }])
           faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key", options)).to eq("toast")
+          expect(kv.get("key", options)).to eq([{
+            key: key,
+            value: 'toast'
+          }])
         end
       end
       context "ACLs enabled, without valid_acl_token" do
@@ -160,7 +166,11 @@ describe Diplomat::Kv do
           }])
           faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get(key)).to eq("Faraday::ResourceNotFound: the server responded with status 404")
+          expect(kv.get(key)).to eq([{
+            key: key,
+            value: "Faraday::ResourceNotFound: the server responded with status 404"
+            }]
+          )
         end
         it "GET with consistency param, without valid_acl_token" do
           options = {:consistency => "consistent"}
@@ -171,7 +181,11 @@ describe Diplomat::Kv do
           }])
           faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key", options)).to eq("Faraday::ResourceNotFound: the server responded with status 404")
+          expect(kv.get("key", options)).to eq([{
+            key: key,
+            value: "Faraday::ResourceNotFound: the server responded with status 404"
+            }]
+          )
         end
       end
       context "ACLs enabled, with valid_acl_token" do
@@ -184,7 +198,10 @@ describe Diplomat::Kv do
           faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
           Diplomat.configuration.acl_token = valid_acl_token
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get(key)).to eq("toast")
+          expect(kv.get(key)).to eq([{
+            key: key,
+            value: 'toast'
+          }])
         end
         it "GET with consistency param, with valid_acl_token" do
           options = {:consistency => "consistent"}
@@ -196,7 +213,10 @@ describe Diplomat::Kv do
           faraday.stub(:get).and_return(OpenStruct.new({ status: 200, body: json }))
           Diplomat.configuration.acl_token = valid_acl_token
           kv = Diplomat::Kv.new(faraday)
-          expect(kv.get("key", options)).to eq("toast")
+          expect(kv.get("key", options)).to eq([{
+            key: key,
+            value: 'toast'
+          }])
         end
       end
     end


### PR DESCRIPTION
Fixes an inconsistency outlined in WeAreFarmGeek/diplomat#39 where a KV `get`
call returns an array if >1 value is returned, but if one value is returned it
strips away the metadata and hands back the raw value.

While this is a friendly thing to do in some cases, it creates a very annoying
inconsistency when doing a recursive `get` which leaves out the metadata
(most importantly the key of the returned value) as well as requiring the
consumer to check whether the return value of `get` is a String or Array.