### PR TITLE
Fixes recursive blocking Kv queries

### DIFF
--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -99,7 +99,7 @@ module Diplomat
         req.url concat_url url
         req.options.timeout = 86400
       end
-      parse_body
+      @raw = parse_body
       return_value(return_nil_values, transformation)
     end
 


### PR DESCRIPTION
The return from `parse_body` wasn't being saved so furthur calls to use
the _parsed_body_ would fail.

Fixes #104
