### PR TITLE
Allow for tag option with Health.service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
  - 2016-08-09 Stefan Merettig <stefan-merettig@nuriaproject.org> Add .respond_to? and .respond_to_missing? to Diplomat::RestClient
  - 2016-09-21 Dana Pieluszczak <dana@greenhouse.io> Add recurse option to Kv#delete
+ - 2016-10-24 Ryan Duffield <rduffield@pagerduty.com> Add tag option to Health#service
 
 ## 0.19.0, 1.0.0
  - 2016-08-02 John Hamelink <john@johnhamelink.com> Improve ACL and Event endpoints by uniformly raising an error for statuscodes which aren't 200.

--- a/lib/diplomat/health.rb
+++ b/lib/diplomat/health.rb
@@ -46,11 +46,13 @@ module Diplomat
     # @param s [String] the service
     # @param options [Hash] :dc string for dc specific query
     # @param options [Hash] :state string for specific service state
+    # @param options [Hash] :tag string for specific tag
     # @return [OpenStruct] all data associated with the node
     def service s, options=nil
       url = ["/v1/health/service/#{s}"]
       url << use_named_parameter('dc', options[:dc]) if options and options[:dc]
       url << options[:state] if options and options[:state]
+      url << use_named_parameter('tag', options[:tag]) if options and options[:tag]
 
       # If the request fails, it's probably due to a bad path
       # so return a PathNotFound error. 

--- a/spec/health_spec.rb
+++ b/spec/health_spec.rb
@@ -220,6 +220,55 @@ EOF
       expect(health.service("foobar", options: options)[0]["Node"]["Node"]).to eq("foobar")
     end
 
+    it "service with tag options" do
+      json = <<EOF
+[
+    {
+        "Node": {
+            "Node": "foobar",
+            "Address": "10.1.10.12"
+        },
+        "Service": {
+            "ID": "redis",
+            "Service": "redis",
+            "Tags": ["v1"],
+            "Port": 8000
+        },
+        "Checks": [
+            {
+                "Node": "foobar",
+                "CheckID": "service:redis",
+                "Name": "Service 'redis' check",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "",
+                "ServiceID": "redis",
+                "ServiceName": "redis"
+            },
+            {
+                "Node": "foobar",
+                "CheckID": "serfHealth",
+                "Name": "Serf Health Status",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "",
+                "ServiceID": "",
+                "ServiceName": ""
+            }
+        ]
+    }
+]
+EOF
+
+      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+
+      health = Diplomat::Health.new(faraday)
+
+      options = { tag: 'v1' }
+
+      expect(health.service("foobar", options: options)[0]["Node"]["Node"]).to eq("foobar")
+    end
+
     it "state" do
       json = <<EOF
 [


### PR DESCRIPTION
This allows for using `options[:tag]` with `Health.service`.