### PR TITLE
Include Consul errors in Diplomat::UnknownStatus messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+ - 2017-01-11 Dylan Vassallo <dylanvassallo@gmail.com> Include Consul errors in Diplomat::UnknownStatus messages
+
 ## 1.2.0
  - 2016-12-15 Trevor Wood <trevor.g.wood@gmail.com> Diplomat::Health returns hashes instead of OpenStructs
 
@@ -27,7 +29,7 @@
 
  - 2016-04-27 Ryan Schlesinger <ryan@outstand.com> Added external service registration
  - 2016-04-27 Improvements to ACL info method when the ACL doesn't exist
- 
+
 ## 0.16.2
 
  - 2016-04-13 Grégoire Seux <g.seux@criteo.com> Refactor HTTP deserialization to allow for raw responses to deserialize properly.

--- a/lib/diplomat/acl.rb
+++ b/lib/diplomat/acl.rb
@@ -37,7 +37,7 @@ module Diplomat
             return nil
         end
       else
-        raise Diplomat::UnknownStatus, "status #{raw.status}"
+        raise Diplomat::UnknownStatus, "status #{raw.status}: #{raw.body}"
       end
     end
 

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -90,7 +90,7 @@ module Diplomat
             index = raw.headers["x-consul-index"]
         end
       else
-        raise Diplomat::UnknownStatus, "status #{raw.status}"
+        raise Diplomat::UnknownStatus, "status #{raw.status}: #{raw.body}"
       end
 
       # Wait for first/next value

--- a/lib/diplomat/maintenance.rb
+++ b/lib/diplomat/maintenance.rb
@@ -40,7 +40,7 @@ module Diplomat
         @raw = raw
         return true
       else
-        raise Diplomat::UnknownStatus, "status #{raw.status}"
+        raise Diplomat::UnknownStatus, "status #{raw.status}: #{raw.body}"
       end
     end
   end

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -136,7 +136,7 @@ module Diplomat
     # Parse the body, apply it to the raw attribute
     def parse_body
       return JSON.parse(@raw.body) if @raw.status == 200
-      raise Diplomat::UnknownStatus, "status #{@raw.status}"
+      raise Diplomat::UnknownStatus, "status #{@raw.status}: #{@raw.body}"
     end
 
     # Return @raw with Value fields decoded

--- a/spec/maintenance_spec.rb
+++ b/spec/maintenance_spec.rb
@@ -96,7 +96,7 @@ EOF
       expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new({ body: "", status: 500}))
       maintenance = Diplomat::Maintenance.new(faraday)
       expect(req).to receive(:url).with('/v1/agent/maintenance?enable=true')
-      expect{ maintenance.enable(true) }.to raise_error(Diplomat::UnknownStatus, 'status 500')
+      expect{ maintenance.enable(true) }.to raise_error(Diplomat::UnknownStatus, 'status 500: ')
     end
   end
 end


### PR DESCRIPTION
Threading Consul errors through to `Diplomat::UnknownStatus` messages would help a lot when triaging application exceptions. 