### PR TITLE
Add optional DC support for locking and sessions

### DIFF
--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -49,7 +49,7 @@ module Diplomat
     # @option options [String] :value the value to set on the key
     # @return [String] The consul KV response body. Can be nil
     def raw action, key, options={}
-      options[:session] ||= Diplomat::Session.create(nil, dc: options[:dc])
+      raise Diplomat::IdParameterRequired unless options[:session]
       raw = @conn.put do |req|
         url = ["/v1/kv/#{key}"]
         url += use_named_parameter(action.to_s, options[:session])

--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -13,15 +13,8 @@ module Diplomat
     # @param value [String] the value for the key
     # @return [Boolean] If the lock was acquired
     def acquire key, session, value=nil
-      raw = @conn.put do |req|
-        url = ["/v1/kv/#{key}"]
-        url += use_named_parameter('acquire', session)
-        url += check_acl_token
-
-        req.url concat_url url
-        req.body = value unless value.nil?
-      end
-      raw.body == 'true'
+      response = raw(:acquire, key, session: session, value: value)
+      response == 'true'
     end
 
     # wait to aquire a lock
@@ -39,18 +32,32 @@ module Diplomat
       end
     end
 
-
     # Release a lock
     # @param key [String] the key
     # @param session [String] the session, generated from Diplomat::Session.create
     # @return [nil]
-    def release  key, session
+    def release key, session
+      raw(:release, key, session: session)
+    end
+
+    # Interact directly with KV endpoint
+    # @param action [Symbol] the locking action to take (:acquire or :release)
+    # @param key [String] the key to lock
+    # @param options [Hash] KV endpoint options
+    # @option options [String] :session the session, generated from Diplomat::Session.create
+    # @option options [String] :dc the target DC
+    # @option options [String] :value the value to set on the key
+    # @return [String] The consul KV response body. Can be nil
+    def raw action, key, options={}
+      options[:session] ||= Diplomat::Session.create(nil, dc: options[:dc])
       raw = @conn.put do |req|
         url = ["/v1/kv/#{key}"]
-        url += use_named_parameter('release', session)
+        url += use_named_parameter(action.to_s, options[:session])
+        url += use_named_parameter('dc', options[:dc])
         url += check_acl_token
 
         req.url concat_url url
+        req.body = options[:value] unless options[:value].nil?
       end
       return raw.body
     end

--- a/lib/diplomat/session.rb
+++ b/lib/diplomat/session.rb
@@ -7,12 +7,17 @@ module Diplomat
 
     # Create a new session
     # @param value [Object] hash or json representation of the session arguments
+    # @param options [Hash] options
+    # @option options [String] :dc DC in which to  create the session
     # @return [String] The sesssion id
-    def create value=nil
+    def create value=nil, options={}
       # TODO: only certain keys are recognised in a session create request,
       # should raise an error on others.
       raw = @conn.put do |req|
-        req.url "/v1/session/create"
+        url = ["/v1/session/create"]
+        url += use_named_parameter('dc', options[:dc])
+
+        req.url concat_url url
         req.body = (if value.kind_of?(String) then value else JSON.generate(value) end) unless value.nil?
       end
       body = JSON.parse(raw.body)
@@ -21,30 +26,44 @@ module Diplomat
 
     # Destroy a session
     # @param id [String] session id
+    # @param options [Hash] options
+    # @option options [String] :dc DC in which to destroy the session
     # @return [nil]
-    def destroy id
+    def destroy id, options={}
       raw = @conn.put do |req|
-        req.url "/v1/session/destroy/#{id}"
+        url = ["/v1/session/destroy/#{id}"]
+        url += use_named_parameter('dc', options[:dc])
+
+        req.url concat_url url
       end
       return raw.body
     end
     
     # List sessions
+    # @param options [Hash] options
+    # @option options [String] :dc DC in which to list sessions
     # @return [Struct]
-    def list
+    def list options={}
       raw = @conn.get do |req|
-        req.url "/v1/session/list"
+        url = ["/v1/session/list"]
+        url += use_named_parameter('dc', options[:dc])
+
+        req.url concat_url url
       end
       JSON.parse(raw.body)
     end
     
     # Renew session
     # @param id [String] session id
+    # @param options [Hash] options
+    # @option options [String] :dc DC in which to renew the session
     # @return [Struct]
-    
-    def renew id
+    def renew id, options={}
       raw = @conn.put do |req|
-        req.url "/v1/session/renew/#{id}"
+        url = ["/v1/session/renew/#{id}"]
+        url += use_named_parameter('dc', options[:dc])
+
+        req.url concat_url url
       end
       JSON.parse(raw.body)
     end


### PR DESCRIPTION
There is currently no support in Diplomat for explicitly specifying a target DC in either Lock or Session libs. This PR adds support in a backwards-compatible manner, using patterns present elsewhere in this repo.

There are several use cases for taking locks in foreign DCs, despite Hashi discouragement - ours is that we are using consul-replicate and want to take a lock while writing to the "master" DC.

Please let me know if I've missed something or if you'd like it to be implemented differently. This approach is meant to be low friction.