### PR TITLE
Defend against newlines added by Consul in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
  - 2017-01-23 Trevor Wood <trevor.g.wood@gmail.com> Add key/value store transaction API endpoint
+ - 2017-01-23 Adam Wentz <adam@adamwentz.com> Defend against newlines added to responses in dev mode where pretty-printing is enabled by default.
 
 ## 1.2.0
  - 2017-01-22 Trevor Wood <trevor.g.wood@gmail.com> RuboCop fixes and add RuboCop checks

--- a/lib/diplomat/acl.rb
+++ b/lib/diplomat/acl.rb
@@ -18,7 +18,7 @@ module Diplomat
       url << use_consistency(options)
 
       raw = @conn_no_err.get concat_url url
-      if raw.status == 200 && raw.body != 'null'
+      if raw.status == 200 && raw.body.chomp != 'null'
         case found
         when :reject
           raise Diplomat::AclAlreadyExists, id
@@ -26,7 +26,7 @@ module Diplomat
           @raw = raw
           return parse_body
         end
-      elsif raw.status == 200 && raw.body == 'null'
+      elsif raw.status == 200 && raw.body.chomp == 'null'
         case not_found
         when :reject
           raise Diplomat::AclNotFound, id
@@ -86,7 +86,7 @@ module Diplomat
       url = ["/v1/acl/destroy/#{@id}"]
       url << check_acl_token
       @raw = @conn.put concat_url url
-      @raw.body == 'true'
+      @raw.body.chomp == 'true'
     end
   end
 end

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -115,9 +115,11 @@ module Diplomat
         req.url concat_url url
         req.body = value
       end
-      @key = key if @raw.body == 'true'
-      @value = value if @raw.body == 'true'
-      @raw.body == 'true'
+      if @raw.body.chomp == 'true'
+        @key = key
+        @value = value
+      end
+      @raw.body.chomp == 'true'
     end
     # rubocop:enable MethodLength, AbcSize
 

--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -11,6 +11,7 @@ module Diplomat
     # @param value [String] the value for the key
     # @param options [Hash] :dc string for dc specific query
     # @return [Boolean] If the lock was acquired
+    # rubocop:disable AbcSize
     def acquire(key, session, value = nil, options = nil)
       raw = @conn.put do |req|
         url = ["/v1/kv/#{key}"]

--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -21,7 +21,7 @@ module Diplomat
         req.url concat_url url
         req.body = value unless value.nil?
       end
-      raw.body.strip == 'true'
+      raw.body.chomp == 'true'
     end
 
     # wait to aquire a lock

--- a/spec/acl_spec.rb
+++ b/spec/acl_spec.rb
@@ -124,7 +124,7 @@ describe Diplomat::Acl do
     describe 'destroy' do
       it 'return the ID' do
         url = key_url + '/destroy/' + id
-        expect(faraday).to receive(:put).with(/#{url}/).and_return(OpenStruct.new(body: 'true', status: 200))
+        expect(faraday).to receive(:put).with(/#{url}/).and_return(OpenStruct.new(body: "true\n", status: 200))
         acl = Diplomat::Acl.new(faraday)
         response = acl.destroy(id)
 

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -330,14 +330,14 @@ describe Diplomat::Kv do
     describe '#put' do
       context 'ACLs NOT enabled' do
         it 'PUT' do
-          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: 'true'))
+          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: "true\n"))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params)).to eq(true)
           expect(kv.value).to eq(key_params)
         end
         it 'PUT with CAS param' do
           options = { cas: modify_index }
-          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: 'true'))
+          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: "true\n"))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params, options)).to eq(true)
           expect(kv.value).to eq(key_params)
@@ -345,20 +345,20 @@ describe Diplomat::Kv do
       end
       context 'ACLs enabled, without valid_acl_token' do
         it 'PUT with ACLs enabled, no valid_acl_token' do
-          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: 'false'))
+          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: "false\n"))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params)).to eq(false)
         end
         it 'PUT with CAS param, without valid_acl_token' do
           options = { cas: modify_index }
-          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: 'false'))
+          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: "false\n"))
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params, options)).to eq(false)
         end
       end
       context 'ACLs enabled, with valid_acl_token' do
         it 'PUT with ACLs enabled, valid_acl_token' do
-          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: 'true'))
+          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: "true\n"))
           Diplomat.configuration.acl_token = valid_acl_token
           kv = Diplomat::Kv.new(faraday)
 
@@ -367,7 +367,7 @@ describe Diplomat::Kv do
         end
         it 'PUT with CAS param' do
           options = { cas: modify_index }
-          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: 'true'))
+          faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: "true\n"))
           Diplomat.configuration.acl_token = valid_acl_token
           kv = Diplomat::Kv.new(faraday)
           expect(kv.put(key, key_params, options)).to eq(true)
@@ -579,7 +579,7 @@ describe Diplomat::Kv do
     end
 
     it 'namespaces' do
-      faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: 'true'))
+      faraday.stub(:put).and_return(OpenStruct.new(status: 200, body: "true\n"))
       kv = Diplomat::Kv.new(faraday)
 
       expect(kv.put("toast/#{key}", key_params)).to eq(true)

--- a/spec/lock_spec.rb
+++ b/spec/lock_spec.rb
@@ -13,7 +13,7 @@ describe Diplomat::Lock do
   context 'lock' do
     context 'without an ACL token configured' do
       before do
-        expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new(body: 'true', status: 200))
+        expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new(body: "true\n", status: 200))
         Diplomat.configure do |c|
           c.acl_token = nil
         end
@@ -40,7 +40,7 @@ describe Diplomat::Lock do
 
         lock = Diplomat::Lock.new(faraday)
 
-        expect(lock.release('lock/key', session)).to eq('true')
+        expect(lock.release('lock/key', session).chomp).to eq('true')
       end
 
       it 'acquires with dc option' do
@@ -64,13 +64,13 @@ describe Diplomat::Lock do
 
         lock = Diplomat::Lock.new(faraday)
 
-        expect(lock.release('lock/key', session, options)).to eq('true')
+        expect(lock.release('lock/key', session, options).chomp).to eq('true')
       end
     end
 
     context 'with an ACL token configured' do
       before do
-        expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new(body: 'true', status: 200))
+        expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new(body: "true\n", status: 200))
         Diplomat.configure do |c|
           c.acl_token = acl_token
         end
@@ -97,7 +97,7 @@ describe Diplomat::Lock do
 
         lock = Diplomat::Lock.new(faraday)
 
-        expect(lock.release('lock/key', session)).to eq('true')
+        expect(lock.release('lock/key', session).chomp).to eq('true')
       end
 
       it 'acquires with dc option' do
@@ -121,7 +121,7 @@ describe Diplomat::Lock do
 
         lock = Diplomat::Lock.new(faraday)
 
-        expect(lock.release('lock/key', session, options)).to eq('true')
+        expect(lock.release('lock/key', session, options).chomp).to eq('true')
       end
     end
   end


### PR DESCRIPTION
As of Consul 0.7.2 pretty-printing is enabled by default in dev mode. This causes incorrect interpretation of return values for a couple of endpoints. This PR changes the equality checks to use ~~`start_with?`~~ the `chomp`'d response instead.

Let me know if you have any suggestions. Thanks for the nice lib!
