### PR TITLE
Fix lock.acquire return status

### DIFF
--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -21,7 +21,7 @@ module Diplomat
         req.url concat_url url
         req.body = value unless value.nil?
       end
-      raw.body == 'true'
+      raw.body.strip == 'true'
     end
 
     # wait to aquire a lock


### PR DESCRIPTION
Hi !
Thanks for this great gem , and your great work

I just noticed that `raw.body.inspect = "true\n"`

This makes `raw.body == 'true'` test always false.
So currently `lock.acquire` def always return false and it makes `wait_to_acquire` looping endlessly :)

This simple modification (adding a `.strip`) should make this test works as intended.

Thanks !