### PR TITLE
allow specifying the datacenter for an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
  - 2017-01-23 Trevor Wood <trevor.g.wood@gmail.com> Add key/value store transaction API endpoint
+ - 2017-02-15 Paul Thomas <paul+github@paulthomas.eu> Allow events to target another datacenter
 
 ## 1.2.0
  - 2017-01-22 Trevor Wood <trevor.g.wood@gmail.com> RuboCop fixes and add RuboCop checks

--- a/lib/diplomat/event.rb
+++ b/lib/diplomat/event.rb
@@ -11,13 +11,15 @@ module Diplomat
     # @param service [String] the target service name
     # @param node [String] the target node name
     # @param tag [String] the target tag name, must only be used with service
+    # @param dc [String] the dc to target
     # @return [nil]
-    def fire(name, value = nil, service = nil, node = nil, tag = nil)
+    def fire(name, value = nil, service = nil, node = nil, tag = nil, dc = nil)
       url = ["/v1/event/fire/#{name}"]
       url += check_acl_token
       url += use_named_parameter('service', service) if service
       url += use_named_parameter('node', node) if node
       url += use_named_parameter('tag', tag) if tag
+      url += use_named_parameter('dc', dc) if dc
 
       @conn.put concat_url(url), value
       nil


### PR DESCRIPTION
Consul events can be targeted to another datacenter by specifying `?dc=foo` this adds an argument to the fire method to allow another dc to be specified