### PR TITLE
Fix parsing of aborted transactions with missing Results field

### DIFF
--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -241,7 +241,7 @@ module Diplomat
     end
 
     def decode_transaction(transaction)
-      return transaction if transaction['Results'].empty?
+      return transaction if transaction['Results'].nil? || transaction['Results'].empty?
 
       transaction.tap do |txn|
         txn['Results'].each do |resp|


### PR DESCRIPTION
In my testing of transaction support, an aborted transaction does
not necessarily contain a Results field, causing decode_transaction
to crash. Fix and add a test.