### PR TITLE
Don't install the `json` gem unnecessarily

### DIFF
--- a/diplomat.gemspec
+++ b/diplomat.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new 'diplomat', Diplomat::VERSION do |spec|
   spec.add_development_dependency 'cucumber', '~> 2.0'
   spec.add_development_dependency 'rubocop', '~> 0.47', '>= 0.47.1'
 
-  spec.add_runtime_dependency 'json'
+  spec.add_runtime_dependency 'json' if RUBY_VERSION < '1.9.3'
   spec.add_runtime_dependency 'faraday', '~> 0.9'
 end


### PR DESCRIPTION
Fixes #144. The `json` library is bundled with Ruby starting with version 1.9.3. As such, there's no need to specify the `json` gem as a dependency on these Ruby versions.