### PR TITLE
Use `PUT` as the verb for deregistering a service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# Next
+
+- 2017-11-09 Josep M. Blanquer (@blanquer) Fix service deregister to use the proper verb (`PUT` instead of `GET`). Consul 1.x seems to
+have started enforcing [it](https://www.consul.io/docs/upgrade-specific.html#http-verbs-are-enforced-in-many-http-apis).
+
 ## 2.0.2
 
 - 2017-08-23 Trevor Wood [trevor.g.wood@gmail.com][1] Revert the change to single values

--- a/diplomat.gemspec
+++ b/diplomat.gemspec
@@ -10,16 +10,16 @@ Gem::Specification.new 'diplomat', Diplomat::VERSION do |spec|
   spec.files         = `git ls-files lib README.md LICENSE features`.split("\n")
 
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'pry', '~> 0.9'
-  spec.add_development_dependency 'rspec', '~> 3.2'
-  spec.add_development_dependency 'fakes-rspec', '~> 2.1'
   spec.add_development_dependency 'codeclimate-test-reporter', '~> 0.4.0'
+  spec.add_development_dependency 'cucumber', '~> 2.0'
+  spec.add_development_dependency 'fakes-rspec', '~> 2.1'
   spec.add_development_dependency 'fivemat', '~> 1.3'
   spec.add_development_dependency 'gem-release', '~> 0.7'
-  spec.add_development_dependency 'cucumber', '~> 2.0'
+  spec.add_development_dependency 'pry', '~> 0.9'
+  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rubocop', '~> 0.47', '>= 0.47.1'
 
-  spec.add_runtime_dependency 'json' if RUBY_VERSION < '1.9.3'
   spec.add_runtime_dependency 'faraday', '~> 0.9'
+  spec.add_runtime_dependency 'json' if RUBY_VERSION < '1.9.3'
 end

--- a/lib/diplomat/configuration.rb
+++ b/lib/diplomat/configuration.rb
@@ -1,7 +1,7 @@
 module Diplomat
   # Methods for configuring Diplomat
   class Configuration
-    attr_accessor :middleware
+    attr_reader :middleware
     attr_accessor :url, :acl_token, :options
 
     # Override defaults for configuration
@@ -18,7 +18,10 @@ module Diplomat
     # Define a middleware for Faraday
     # @param middleware [Class] Faraday Middleware class
     def middleware=(middleware)
-      return @middleware = middleware if middleware.is_a? Array
+      if middleware.is_a? Array
+        @middleware = middleware
+        return
+      end
       @middleware = [middleware]
     end
   end

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -248,14 +248,17 @@ module Diplomat
       OpenStruct.new decoded_return
     end
 
-    def decode_transaction(transaction)
+    def decode_transaction(transaction) # rubocop:disable Metrics/MethodLength
       return transaction if transaction['Results'].nil? || transaction['Results'].empty?
 
       transaction.tap do |txn|
         txn['Results'].each do |resp|
           next unless resp['KV']['Value']
-          value = resp['KV']['Value']
-          resp['KV']['Value'] = Base64.decode64(value) rescue nil # rubocop:disable RescueModifier
+          begin
+            resp['KV']['Value'] = Base64.decode64(resp['KV']['Value'])
+          rescue # rubocop:disable RescueWithoutErrorClass
+            nil
+          end
         end
       end
     end

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -141,7 +141,11 @@ module Diplomat
     def decode_values
       return @raw if @raw.first.is_a? String
       @raw.each_with_object([]) do |acc, el|
-        acc['Value'] = Base64.decode64(acc['Value']) rescue nil # rubocop:disable RescueModifier
+        begin
+          acc['Value'] = Base64.decode64(acc['Value'])
+        rescue # rubocop:disable RescueWithoutErrorClass
+          nil
+        end
         el << acc
         el
       end

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -75,7 +75,7 @@ module Diplomat
     # @param service_name [String] Service name to de-register
     # @return [Boolean]
     def deregister(service_name)
-      deregister = @conn.get "/v1/agent/service/deregister/#{service_name}"
+      deregister = @conn.put "/v1/agent/service/deregister/#{service_name}"
       deregister.status == 200
     end
 

--- a/spec/agent_spec.rb
+++ b/spec/agent_spec.rb
@@ -7,7 +7,7 @@ describe Diplomat::Agent do
 
   context 'agent' do
     it 'self' do
-      faraday.stub(:get).and_return(OpenStruct.new(body: <<-EOF))
+      faraday.stub(:get).and_return(OpenStruct.new(body: <<-JSON))
 		{
 		  "Config": {
 			"Bootstrap": true,
@@ -73,7 +73,7 @@ describe Diplomat::Agent do
 			"DelegateCur": 4
 		  }
 		}
-      EOF
+      JSON
 
       agent = Diplomat::Agent.new(faraday)
 
@@ -81,7 +81,7 @@ describe Diplomat::Agent do
     end
 
     it 'checks' do
-      faraday.stub(:get).and_return(OpenStruct.new(body: <<-EOF))
+      faraday.stub(:get).and_return(OpenStruct.new(body: <<-JSON))
 		{
 		  "service:redis": {
 			"Node": "foobar",
@@ -94,7 +94,7 @@ describe Diplomat::Agent do
 			"ServiceName": "redis"
 		  }
 		}
-      EOF
+      JSON
 
       agent = Diplomat::Agent.new(faraday)
 
@@ -102,7 +102,7 @@ describe Diplomat::Agent do
     end
 
     it 'services' do
-      faraday.stub(:get).and_return(OpenStruct.new(body: <<-EOF))
+      faraday.stub(:get).and_return(OpenStruct.new(body: <<-JSON))
 		{
 		  "redis": {
 			"ID": "redis",
@@ -112,7 +112,7 @@ describe Diplomat::Agent do
 			"Port": 8000
 		  }
 		}
-      EOF
+      JSON
 
       agent = Diplomat::Agent.new(faraday)
 
@@ -120,7 +120,7 @@ describe Diplomat::Agent do
     end
 
     it 'members' do
-      faraday.stub(:get).and_return(OpenStruct.new(body: <<-EOF))
+      faraday.stub(:get).and_return(OpenStruct.new(body: <<-JSON))
 		[
 		  {
 			"Name": "foobar",
@@ -141,7 +141,7 @@ describe Diplomat::Agent do
 			"DelegateCur": 3
 		  }
 		]
-      EOF
+      JSON
 
       agent = Diplomat::Agent.new(faraday)
 

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -231,7 +231,7 @@ describe Diplomat::Service do
 
       it 'can deregister a service' do
         url = "#{deregister_service_url}/#{service_definition[:name]}"
-        expect(faraday).to receive(:get).with(url) do
+        expect(faraday).to receive(:put).with(url) do
           OpenStruct.new(body: '', status: 200)
         end
         service = Diplomat::Service.new(faraday)


### PR DESCRIPTION
Consul 1.0 has started to enforce the verbs used:
*https://www.consul.io/docs/upgrade-specific.html#http-verbs-are-enforced-in-many-http-apis