### PR TITLE
Suggest using X-Consul-Token for ACL tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,8 @@ Diplomat.configure do |config|
   config.url = "http://localhost:8888"
   # Set up a custom Faraday Middleware
   config.middleware = MyCustomMiddleware
-  # Connect into consul with custom access token (ACL)
-  config.acl_token =  "xxxxxxxx-yyyy-zzzz-1111-222222222222"
-  # Set extra Faraday configuration options
-  config.options = {ssl: { version: :TLSv1_2 }}
+  # Set extra Faraday configuration options and custom access token (ACL)
+  config.options = {ssl: {version: :TLSv1_2}, headers: {"X-Consul-Token" => "xxxxxxxx-yyyy-zzzz-1111-222222222222"}}
 end
 ```
 


### PR DESCRIPTION
This PR is just a suggested README change, but it fixes two issues concerning ACL tokens. The [Consul documentation](https://www.consul.io/api/index.html#authentication) says:

> When authentication is enabled, a Consul token should be provided to API requests using the X-Consul-Token header. This reduces the probability of the token accidentally getting logged or exposed. [...] Previously this was provided via a ?token= query parameter. This functionality exists on many endpoints for backwards compatibility, but its use is highly discouraged, since it can show up in access logs as part of the URL.

The `config.acl_token` setting in Diplomat sets the `token` query string parameter rather than the header. Additionally, it does not set it for all API endpoints (e.g., Sessions), so some functionality simply does work when using `config.acl_token`. Setting the header instead fixes both issues.