### PR TITLE
add option to search all nodes and services filtering by metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # Next
 
+- 2018-01-26 Nate St. Germain (@rockpapergoat) Add option to search all nodes by metadata
+  Pass a `:meta` hash as an option to `Diplomat::Node.get_all` to filter on metadata.
+
 - 2017-11-09 Josep M. Blanquer (@blanquer) Fix service deregister to use the proper verb (`PUT` instead of `GET`). Consul 1.x seems to
 have started enforcing [it](https://www.consul.io/docs/upgrade-specific.html#http-verbs-are-enforced-in-many-http-apis).
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ Get all nodes for a particular datacenter
 nodes = Diplomat::Node.get_all({ :dc => 'My_Datacenter' })
 # => [#<OpenStruct Address="10.1.10.12", Node="foo">, #<OpenStruct Address="10.1.10.13", Node="bar">]
 ```
+Get all nodes with specified metadata
+
+NOTE: This requires adding metadata to nodes, either as part of the agent config or via the catalog. Adding multiple metadata attributes effectively is an `AND` operation here.
+
+```ruby
+nodes = Diplomat::Node.get_all({ :meta => {'role' => 'server', 'availability_zone' => 'us-east-1d'})
+# => [#<OpenStruct Node="i-003b17883f403eda5", Address="10.10.10.210", Datacenter="dev", TaggedAddresses={"lan"=>"10.10.10.210", "wan"=>"10.10.10.210"}, Meta={"availability_zone"=>"us-east-1d", "consul-network-segment"=>"", "environment"=>"dev", "instance_type"=>"t2.small", "ip"=>"10.10.10.210", "lsb_release"=>"16.04", "role"=>"server", "tags"=>""}>]
+```
 
 Register a node:
 

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ end
 
 desc 'Run a bootstrapped consul server for testing'
 task :consul do
-  system('consul agent -server -bootstrap -data-dir=/tmp')
+  system('consul agent -dev -bootstrap -data-dir=/tmp')
 end
 
 task default: %w[style spec]

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -256,7 +256,7 @@ module Diplomat
           next unless resp['KV']['Value']
           begin
             resp['KV']['Value'] = Base64.decode64(resp['KV']['Value'])
-          rescue # rubocop:disable RescueWithoutErrorClass
+          rescue StandardError
             nil
           end
         end

--- a/lib/diplomat/node.rb
+++ b/lib/diplomat/node.rb
@@ -23,11 +23,14 @@ module Diplomat
     end
 
     # Get all the nodes
-    # @param options [Hash] :dc string for dc specific query
+    # @param options [Hash]
+    #   :dc string for dc specific query
+    #   :meta hash for metadata query
     # @return [OpenStruct] the list of all nodes
-    def get_all(options = nil)
+    def get_all(options = nil) # rubocop:disable Metrics/AbcSize
       url = ['/v1/catalog/nodes']
       url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
+      url << options[:meta].map { |m| use_named_parameter('node-meta', m.join(':')) } if options && options[:meta]
 
       ret = @conn.get concat_url url
       JSON.parse(ret.body).map { |service| OpenStruct.new service }

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -3,7 +3,7 @@ module Diplomat
   class RestClient
     @access_methods = []
 
-    # Initialize the fadaray connection
+    # Initialize the faraday connection
     # @param api_connection [Faraday::Connection,nil] supply mock API Connection
     def initialize(api_connection = nil)
       start_connection api_connection
@@ -143,7 +143,7 @@ module Diplomat
       @raw.each_with_object([]) do |acc, el|
         begin
           acc['Value'] = Base64.decode64(acc['Value'])
-        rescue # rubocop:disable RescueWithoutErrorClass
+        rescue StandardError
           nil
         end
         el << acc

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -5,7 +5,7 @@ module Diplomat
 
     @access_methods = %i[get get_all register deregister register_external deregister_external maintenance]
 
-    # Get a service by it's key
+    # Get a service by its key
     # @param key [String] the key
     # @param scope [Symbol] :first or :all results
     # @param options [Hash] options parameter hash
@@ -47,12 +47,15 @@ module Diplomat
     # rubocop:enable PerceivedComplexity, MethodLength, CyclomaticComplexity, AbcSize
 
     # Get all the services
-    # @param options [Hash] :dc Consul datacenter to query
+    # @param options [Hash]
+    #   :dc Consul datacenter to query
+    #   :meta hash for metadata query
     # @return [OpenStruct] the list of all services
-    def get_all(options = nil)
+    def get_all(options = nil) # rubocop:disable Metrics/AbcSize
       url = ['/v1/catalog/services']
       url += check_acl_token
       url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
+      url << options[:meta].map { |m| use_named_parameter('node-meta', m.join(':')) } if options && options[:meta]
       begin
         ret = @conn.get concat_url url
       rescue Faraday::ClientError

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -58,6 +58,26 @@ describe Diplomat::Node do
         }
       ]
     end
+    let(:body_all_with_meta) do
+      [
+        {
+          'Address' => '10.1.10.12',
+          'Node' => 'foo',
+          'Meta' => {
+            'role' => 'redis',
+            'az' => 'us-east-1a'
+          }
+        },
+        {
+          'Address' => '10.1.10.13',
+          'Node' => 'bar',
+          'Meta' => {
+            'role' => 'redis',
+            'az' => 'us-east-1a'
+          }
+        }
+      ]
+    end
     let(:body) do
       {
         'Node' => {
@@ -83,6 +103,7 @@ describe Diplomat::Node do
       }
     end
     let(:all_with_dc_url) { '/v1/catalog/nodes?dc=dc1' }
+    let(:all_with_meta_url) { '/v1/catalog/nodes?node-meta=az:us-east-1a&node-meta=role:redis' }
     let(:body_all_with_dc) do
       [
         {
@@ -112,6 +133,25 @@ describe Diplomat::Node do
       end
     end
 
+    describe 'GET ALL WITH METADATA' do
+      it 'lists all the nodes with specified metadata' do
+        json = JSON.generate(body_all_with_meta)
+
+        faraday.stub(:get).with(all_with_meta_url).and_return(OpenStruct.new(body: json))
+
+        node = Diplomat::Node.new(faraday)
+        expect(node.get_all(:meta => {'az' => 'us-east-1a','role' => 'redis'}).size).to eq(2)
+      end
+
+      it 'lists all the nodes' do
+        json = JSON.generate(body_all_with_dc)
+
+        faraday.stub(:get).with(all_with_dc_url).and_return(OpenStruct.new(body: json))
+
+        node = Diplomat::Node.new(faraday)
+        expect(node.get_all(dc: 'dc1').size).to eq(1)
+      end
+    end
     describe 'GET' do
       let(:cn) do
         json = JSON.generate(body)


### PR DESCRIPTION
These small changes add options to the node and server `get_all` methods to allow including metadata filters in the URL passed to the consul API. I updated the spec tests and docs to reflect this change, but let me know if you need anything else here. Thanks!