### PR TITLE
CI: Update to current set of Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ before_install:
   - gem install bundler
 rvm:
     - "2.2.10"
-    - "2.3.7"
-    - "2.4.4"
-    - "2.5.1"
+    - "2.3.8"
+    - "2.4.5"
+    - "2.5.3"
+    - "2.6.0-rc1"
 addons:
     code_climate:
         repo_token: 0c910d8f8af55cc2d2f38170d5362be4e16be8ce232df9c565057985af264b7b

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,11 @@ language: ruby
 before_install: 
   - gem install bundler
 rvm:
-    - "2.2.10"
-    - "2.3.8"
-    - "2.4.5"
-    - "2.5.3"
-    - "2.6.0-rc2"
-matrix:
-  allow_failures:
-    - rvm: 2.6.0-rc2
+    - 2.2.10
+    - 2.3.8
+    - 2.4.5
+    - 2.5.3
+    - 2.6.0-rc2
 addons:
     code_climate:
         repo_token: 0c910d8f8af55cc2d2f38170d5362be4e16be8ce232df9c565057985af264b7b

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ rvm:
     - "2.3.8"
     - "2.4.5"
     - "2.5.3"
-    - "2.6.0-rc1"
+    - "2.6.0-rc2"
+matrix:
+  allow_failures:
+    - rvm: 2.6.0-rc2
 addons:
     code_climate:
         repo_token: 0c910d8f8af55cc2d2f38170d5362be4e16be8ce232df9c565057985af264b7b


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known

I included 2.6.0-rc1, since its release is so near, and it would be nice to support it as soon as possible. **Update**: 2.6.0-rc2.