### PR TITLE
fix case where real_size = 0

### DIFF
--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -109,14 +109,10 @@ module Diplomat
       data.each do |item|
         split_up = item[:key].split('/')
         sub_hash = {}
-        temp = nil
+        temp = {}
         real_size = split_up.size - 1
-        (0..real_size).each do |i|
-          if i.zero?
-            temp = {}
-            sub_hash[split_up[i]] = temp
-            next
-          end
+	sub_hash[split_up[0]] = real_size.zero? ? item[:value] : temp
+        (1..real_size).each do |i|
           if i == real_size
             temp[split_up[i]] = item[:value]
           else


### PR DESCRIPTION
if real_size is zero, ie

key => foo
value => bar

convert_to_hash creates foo => {} rather than foo => bar 
