### PR TITLE
simpler convert_to_hash function

### DIFF
--- a/diplomat.gemspec
+++ b/diplomat.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new 'diplomat', Diplomat::VERSION do |spec|
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rubocop', '~> 0.49'
 
+  spec.add_runtime_dependency 'deep_merge', '~> 1.0', '>= 1.0.1'
   spec.add_runtime_dependency 'faraday', '~> 0.9'
   spec.add_runtime_dependency 'json_pure' if RUBY_VERSION < '1.9.3'
 end

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -137,6 +137,11 @@ describe Diplomat::Kv do
                 'Key' => key + '/iamnil',
                 'Value' => nil,
                 'Flags' => 0
+              },
+              {
+                'Key' => 'foo',
+                'Value' => Base64.encode64('bar'),
+                'Flags' => 0
               }
             ]
           )
@@ -148,6 +153,7 @@ describe Diplomat::Kv do
           answer = {}
           answer[key] = {}
           answer[key]['dewfr'] = 'toast'
+          answer['foo'] = 'bar'
           expect(kv.get(key, recurse: true, convert_to_hash: true)).to eql(answer)
         end
         it 'GET with nil values' do
@@ -157,6 +163,7 @@ describe Diplomat::Kv do
           answer[key] = {}
           answer[key]['dewfr'] = 'toast'
           answer[key]['iamnil'] = nil
+          answer['foo'] = 'bar'
           expect(kv.get(key, recurse: true, convert_to_hash: true, nil_values: true)).to eql(answer)
         end
 


### PR DESCRIPTION
if real_size is zero, ie

:key => 'foo'
:value => 'bar'

convert_to_hash creates 'foo '=> {} rather than 'foo' => 'bar'