### PR TITLE
Enable configuration override on each consul api call

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,11 +2,23 @@
 AllCops:
   DisplayCopNames: true
 
+Metrics/AbcSize:
+  Max: 60
+
+Metrics/CyclomaticComplexity:
+  Max: 15
+
 Metrics/LineLength:
   # This will disable the rule completely, regardless what other options you put
   Enabled: true
   # Change the default 80 chars limit value
   Max: 120
+
+Metrics/MethodLength:
+  # This cop checks if the length of a method exceeds some maximum value
+  Enabled: true
+  # Change the default 10 lines limit value
+  Max: 50
 
 # Allow classes longer than 100 lines of code
 ClassLength:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Gem Version](https://badge.fury.io/rb/diplomat.svg)](https://rubygems.org/gems/diplomat) [![Gem](https://img.shields.io/gem/dt/diplomat.svg)](https://rubygems.org/gems/diplomat/versions/2.0.0) [![Build Status](https://travis-ci.org/WeAreFarmGeek/diplomat.svg?branch=master)](https://travis-ci.org/WeAreFarmGeek/diplomat) [![Code Climate](https://codeclimate.com/github/johnhamelink/diplomat.svg)](https://codeclimate.com/github/WeAreFarmGeek/diplomat) [![Inline docs](http://inch-ci.org/github/wearefarmgeek/diplomat.svg?branch=master)](http://inch-ci.org/github/wearefarmgeek/diplomat)
 ### A HTTP Ruby API for [Consul](http://www.consul.io/)
 
-![Diplomacy Boad Game](http://i.imgur.com/Nkuy4b7.jpg)
+![Diplomacy Board Game](http://i.imgur.com/Nkuy4b7.jpg)
 
 
 ## FAQ
@@ -316,6 +316,14 @@ end
 ```
 
 This is traditionally kept inside the `config/initializers` directory if you're using rails. The middleware allows you to customise what happens when faraday sends and receives data. This can be useful if you want to instrument your use of diplomat, for example. You can read more about Faraday's custom middleware [here](http://stackoverflow.com/a/20973008).
+
+Alternatively, configuration settings can be overriden at each method call allowing for instance to address different consul agents, with some other token.
+
+```ruby
+Diplomat::Service.get('foo', { http_addr: 'http://consu01:8500' })
+Diplomat::Service.get('foo', { http_addr: 'http://consu02:8500' })
+Diplomat::Kv.put('key/path', 'value', { http_addr: 'http://localhost:8500', dc: 'dc1', token: '111-222-333-444-555' })
+```
 
 ### Todo
 

--- a/diplomat.gemspec
+++ b/diplomat.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new 'diplomat', Diplomat::VERSION do |spec|
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.2'
   spec.add_development_dependency 'rubocop', '~> 0.49'
+  spec.add_development_dependency 'webmock'
 
   spec.add_runtime_dependency 'deep_merge', '~> 1.0', '>= 1.0.1'
   spec.add_runtime_dependency 'faraday', '~> 0.9'

--- a/lib/diplomat/agent.rb
+++ b/lib/diplomat/agent.rb
@@ -8,62 +8,34 @@ module Diplomat
     @access_methods = %i[self checks services members]
 
     # Get agent configuration
+    # @param options [Hash] options parameter hash
     # @return [OpenStruct] all data associated with the node
-    def self
-      url = ['/v1/agent/self']
-
-      # If the request fails, it's probably due to a bad path
-      # so return a PathNotFound error.
-      begin
-        ret = @conn.get concat_url url
-      rescue Faraday::ClientError
-        raise Diplomat::PathNotFound
-      end
+    def self(options = {})
+      ret = send_get_request(@conn, ['/v1/agent/self'], options)
       JSON.parse(ret.body).tap { |node| OpenStruct.new node }
     end
 
     # Get local agent checks
+    # @param options [Hash] options parameter hash
     # @return [OpenStruct] all agent checks
-    def checks
-      url = ['/v1/agent/checks']
-
-      # If the request fails, it's probably due to a bad path
-      # so return a PathNotFound error.
-      begin
-        ret = @conn.get concat_url url
-      rescue Faraday::ClientError
-        raise Diplomat::PathNotFound
-      end
+    def checks(options = {})
+      ret = send_get_request(@conn, ['/v1/agent/checks'], options)
       JSON.parse(ret.body).tap { |node| OpenStruct.new node }
     end
 
     # Get local agent services
+    # @param options [Hash] options parameter hash
     # @return [OpenStruct] all agent services
-    def services
-      url = ['/v1/agent/services']
-
-      # If the request fails, it's probably due to a bad path
-      # so return a PathNotFound error.
-      begin
-        ret = @conn.get concat_url url
-      rescue Faraday::ClientError
-        raise Diplomat::PathNotFound
-      end
+    def services(options = {})
+      ret = send_get_request(@conn, ['/v1/agent/services'], options)
       JSON.parse(ret.body).tap { |node| OpenStruct.new node }
     end
 
     # Get cluster members (as seen by the agent)
+    # @param options [Hash] options parameter hash
     # @return [OpenStruct] all members
-    def members
-      url = ['/v1/agent/members']
-
-      # If the request fails, it's probably due to a bad path
-      # so return a PathNotFound error.
-      begin
-        ret = @conn.get concat_url url
-      rescue Faraday::ClientError
-        raise Diplomat::PathNotFound
-      end
+    def members(options = {})
+      ret = send_get_request(@conn, ['/v1/agent/members'], options)
       JSON.parse(ret.body).map { |node| OpenStruct.new node }
     end
   end

--- a/lib/diplomat/datacenter.rb
+++ b/lib/diplomat/datacenter.rb
@@ -5,16 +5,15 @@ module Diplomat
 
     # Get an array of all avaliable datacenters accessible by the local consul agent
     # @param meta [Hash] output structure containing header information about the request (index)
+    # @param options [Hash] options parameter hash
     # @return [OpenStruct] all datacenters avaliable to this consul agent
-    def get(meta = nil)
-      url = ['/v1/catalog/datacenters']
-
-      ret = @conn.get concat_url url
+    def get(meta = nil, options = {})
+      ret = send_get_request(@conn, ['/v1/catalog/datacenters'], options)
 
       if meta && ret.headers
-        meta[:index] = ret.headers['x-consul-index']
-        meta[:knownleader] = ret.headers['x-consul-knownleader']
-        meta[:lastcontact] = ret.headers['x-consul-lastcontact']
+        meta[:index] = ret.headers['x-consul-index'] if ret.headers['x-consul-index']
+        meta[:knownleader] = ret.headers['x-consul-knownleader'] if ret.headers['x-consul-knownleader']
+        meta[:lastcontact] = ret.headers['x-consul-lastcontact'] if ret.headers['x-consul-lastcontact']
       end
       JSON.parse(ret.body)
     end

--- a/lib/diplomat/error.rb
+++ b/lib/diplomat/error.rb
@@ -11,4 +11,5 @@ module Diplomat
   class UnknownStatus < StandardError; end
   class IdParameterRequired < StandardError; end
   class InvalidTransaction < StandardError; end
+  class DeprecatedArgument < StandardError; end
 end

--- a/lib/diplomat/event.rb
+++ b/lib/diplomat/event.rb
@@ -10,17 +10,17 @@ module Diplomat
     # @param node [String] the target node name
     # @param tag [String] the target tag name, must only be used with service
     # @param dc [String] the dc to target
+    # @param options [Hash] options parameter hash
     # @return [nil]
     # rubocop:disable Metrics/ParameterLists
-    def fire(name, value = nil, service = nil, node = nil, tag = nil, dc = nil)
-      url = ["/v1/event/fire/#{name}"]
-      url += check_acl_token
-      url += use_named_parameter('service', service) if service
-      url += use_named_parameter('node', node) if node
-      url += use_named_parameter('tag', tag) if tag
-      url += use_named_parameter('dc', dc) if dc
+    def fire(name, value = nil, service = nil, node = nil, tag = nil, dc = nil, options = {})
+      custom_params = []
+      custom_params << use_named_parameter('service', service) if service
+      custom_params << use_named_parameter('node', node) if node
+      custom_params << use_named_parameter('tag', tag) if tag
+      custom_params << use_named_parameter('dc', dc) if dc
 
-      @conn.put concat_url(url), value
+      send_put_request(@conn, ["/v1/event/fire/#{name}"], options, value, custom_params)
       nil
     end
     # rubocop:enable Metrics/ParameterLists
@@ -32,6 +32,7 @@ module Diplomat
     # @param found [Symbol] behaviour if there are already events matching name;
     #   :reject with exception, :return its current value, or :wait for its next value
     # @return [Array[hash]] The list of { :name, :payload } hashes
+    # @param options [Hash] options parameter hash
     # @note
     #   Events are sent via the gossip protocol; there is no guarantee of delivery
     #   success or order, but the local agent will store up to 256 events that do
@@ -55,15 +56,9 @@ module Diplomat
     #   - W R - get the first or current value; always return something, but
     #           block only when necessary
     #   - W W - get the first or next value; wait until there is an update
-    # rubocop:disable MethodLength, AbcSize
-    def get_all(name = nil, not_found = :reject, found = :return)
-      url = ['/v1/event/list']
-      url += check_acl_token
-      url += use_named_parameter('name', name)
-      url = concat_url url
-
+    def get_all(name = nil, not_found = :reject, found = :return, options = {})
       # Event list never returns 404 or blocks, but may return an empty list
-      @raw = @conn.get url
+      @raw = send_get_request(@conn, ['/v1/event/list'], options, use_named_parameter('name', name))
       if JSON.parse(@raw.body).count.zero?
         case not_found
         when :reject
@@ -76,19 +71,15 @@ module Diplomat
         when :reject
           raise Diplomat::EventAlreadyExists, name
         when :return
-          # Always set the response to 200 so we always return
-          # the response body.
-          @raw.status = 200
           @raw = parse_body
           return return_payload
         end
       end
 
-      @raw = wait_for_next_event(url)
+      @raw = wait_for_next_event(['/v1/event/list'], options, use_named_parameter('name', name))
       @raw = parse_body
       return_payload
     end
-    # rubocop:enable MethodLength, AbcSize
 
     # Get a specific event in the sequence matching name
     # @param name [String] the name of the event (regex)
@@ -102,6 +93,7 @@ module Diplomat
     # @return [hash] A hash with keys :value and :token;
     #   :value is a further hash of the :name and :payload of the event,
     #   :token is the event's ordinate in the sequence and can be passed to future calls to get the subsequent event
+    # @param options [Hash] options parameter hash
     # @note
     #   Whereas the consul API for events returns all past events that match
     #   name, this method allows retrieval of individual events from that
@@ -110,12 +102,9 @@ module Diplomat
     #   middle, though these can only be identified relative to the preceding
     #   event. However, this is ideal for iterating through the sequence of
     #   events (while being sure that none are missed).
-    # rubocop:disable MethodLength, CyclomaticComplexity, AbcSize
-    def get(name = nil, token = :last, not_found = :wait, found = :return)
-      url = ['/v1/event/list']
-      url += check_acl_token
-      url += use_named_parameter('name', name)
-      @raw = @conn.get concat_url url
+    # rubocop:disable PerceivedComplexity
+    def get(name = nil, token = :last, not_found = :wait, found = :return, options = {})
+      @raw = send_get_request(@conn, ['/v1/event/list'], options, use_named_parameter('name', name))
       body = JSON.parse(@raw.body)
       # TODO: deal with unknown symbols, invalid indices (find_index will return nil)
       idx = case token
@@ -124,7 +113,7 @@ module Diplomat
             when :next then body.length
             else body.find_index { |e| e['ID'] == token } + 1
             end
-      if idx == body.length
+      if JSON.parse(@raw.body).count.zero? || idx == body.length
         case not_found
         when :reject
           raise Diplomat::EventNotFound, name
@@ -133,7 +122,7 @@ module Diplomat
           event_payload = ''
           event_token = :last
         when :wait
-          @raw = wait_for_next_event(url)
+          @raw = wait_for_next_event(['/v1/event/list'], options, use_named_parameter('name', name))
           @raw = parse_body
           # If it's possible for two events to arrive at once,
           # this needs to #find again:
@@ -149,7 +138,7 @@ module Diplomat
         when :return
           event = body[idx]
           event_name = event['Name']
-          event_payload = Base64.decode64(event['Payload'])
+          event_payload = event['Payload'].nil? ? nil : Base64.decode64(event['Payload'])
           event_token = event['ID']
         end
       end
@@ -159,17 +148,19 @@ module Diplomat
         token: event_token
       }
     end
-    # rubocop:enable MethodLength, CyclomaticComplexity, AbcSize
+    # rubocop:enable PerceivedComplexity
 
     private
 
-    def wait_for_next_event(url)
-      index = @raw.headers['x-consul-index']
-      url = [url, use_named_parameter('index', index)].join('&')
-      @conn.get do |req|
-        req.url concat_url url
-        req.options.timeout = 86_400
+    def wait_for_next_event(url, options = {}, param = nil)
+      if options.nil?
+        options = { timeout: 86_400 }
+      else
+        options[:timeout] = 86_400
       end
+      index = @raw.headers['x-consul-index']
+      param += use_named_parameter('index', index)
+      send_get_request(@conn, url, options, param)
     end
   end
 end

--- a/lib/diplomat/health.rb
+++ b/lib/diplomat/health.rb
@@ -8,75 +8,55 @@ module Diplomat
     # @param n [String] the node
     # @param options [Hash] :dc string for dc specific query
     # @return [OpenStruct] all data associated with the node
-    def node(n, options = nil)
-      url = ["/v1/health/node/#{n}"]
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
+    def node(n, options = {})
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
 
-      # If the request fails, it's probably due to a bad path
-      # so return a PathNotFound error.
-      ret = @conn.get concat_url url
+      ret = send_get_request(@conn, ["/v1/health/node/#{n}"], options, custom_params)
       JSON.parse(ret.body).map { |node| OpenStruct.new node }
-    rescue Faraday::ClientError
-      raise Diplomat::PathNotFound
     end
 
     # Get service checks
     # @param s [String] the service
     # @param options [Hash] :dc string for dc specific query
     # @return [OpenStruct] all data associated with the node
-    def checks(s, options = nil)
-      url = ["/v1/health/checks/#{s}"]
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
+    def checks(s, options = {})
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
 
-      # If the request fails, it's probably due to a bad path
-      # so return a PathNotFound error.
-      ret = @conn.get concat_url url
+      ret = send_get_request(@conn, ["/v1/health/checks/#{s}"], options, custom_params)
       JSON.parse(ret.body).map { |check| OpenStruct.new check }
-    rescue Faraday::ClientError
-      raise Diplomat::PathNotFound
     end
 
     # Get service health
     # @param s [String] the service
-    # @param options [Hash] :dc string for dc specific query
-    # @param options [Hash] :passing boolean to return only checks in passing state
-    # @param options [Hash] :tag string for specific tag
+    # @param options [Hash] options parameter hash
     # @return [OpenStruct] all data associated with the node
-    # rubocop:disable PerceivedComplexity, CyclomaticComplexity, AbcSize
-    def service(s, options = nil)
-      url = ["/v1/health/service/#{s}"]
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
-      url << 'passing' if options && options[:passing]
-      url << use_named_parameter('tag', options[:tag]) if options && options[:tag]
-      url << use_named_parameter('near', options[:near]) if options && options[:near]
+    # rubocop:disable PerceivedComplexity
+    def service(s, options = {})
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
+      custom_params << ['passing'] if options[:passing]
+      custom_params << use_named_parameter('tag', options[:tag]) if options[:tag]
+      custom_params << use_named_parameter('near', options[:near]) if options[:near]
 
-      # If the request fails, it's probably due to a bad path
-      # so return a PathNotFound error.
-      ret = @conn.get concat_url url
+      ret = send_get_request(@conn, ["/v1/health/service/#{s}"], options, custom_params)
       JSON.parse(ret.body).map { |service| OpenStruct.new service }
-    rescue Faraday::ClientError
-      raise Diplomat::PathNotFound
     end
-    # rubocop:enable PerceivedComplexity, CyclomaticComplexity, AbcSize
+    # rubocop:enable PerceivedComplexity
 
     # Get service health
     # @param s [String] the state ("any", "passing", "warning", or "critical")
     # @param options [Hash] :dc string for dc specific query
     # @return [OpenStruct] all data associated with the node
-    # rubocop:disable AbcSize
-    def state(s, options = nil)
-      url = ["/v1/health/state/#{s}"]
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
-      url << use_named_parameter('near', options[:near]) if options && options[:near]
+    def state(s, options = {})
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
+      custom_params << use_named_parameter('near', options[:near]) if options[:near]
 
-      # If the request fails, it's probably due to a bad path
-      # so return a PathNotFound error.
-      ret = @conn.get concat_url url
+      ret = send_get_request(@conn, ["/v1/health/state/#{s}"], options, custom_params)
       JSON.parse(ret.body).map { |status| OpenStruct.new status }
-    rescue Faraday::ClientError
-      raise Diplomat::PathNotFound
     end
-    # rubocop:enable AbcSize
 
     # Convenience method to get services in any state
     def any

--- a/lib/diplomat/members.rb
+++ b/lib/diplomat/members.rb
@@ -4,9 +4,10 @@ module Diplomat
     @access_methods = [:get]
 
     # Get all members
+    # @param options [Hash] options parameter hash
     # @return [OpenStruct] all data associated with the service
-    def get
-      ret = @conn.get '/v1/agent/members'
+    def get(options = {})
+      ret = send_get_request(@conn, ['/v1/agent/members'], options)
       JSON.parse(ret.body)
     end
   end

--- a/lib/diplomat/nodes.rb
+++ b/lib/diplomat/nodes.rb
@@ -6,20 +6,17 @@ module Diplomat
 
     # Get all nodes
     # @deprecated Please use Diplomat::Node instead.
+    # @param options [Hash] options parameter hash
     # @return [OpenStruct] all data associated with the nodes in catalog
-    def get
-      ret = @conn.get '/v1/catalog/nodes'
+    def get(options = {})
+      ret = send_get_request(@conn, ['/v1/catalog/nodes'], options)
       JSON.parse(ret.body)
     end
 
-    def get_all(options = nil)
-      url = ['/v1/catalog/nodes']
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
-
-      ret = @conn.get concat_url url
+    def get_all(options = {})
+      custom_params = options[:dc] ? use_named_parameter('dc', options[:dc]) : nil
+      ret = send_get_request(@conn, ['/v1/catalog/nodes'], options, custom_params)
       JSON.parse(ret.body).map { |service| OpenStruct.new service }
-    rescue Faraday::ClientError
-      raise Diplomat::PathNotFound
     end
   end
 end

--- a/lib/diplomat/query.rb
+++ b/lib/diplomat/query.rb
@@ -7,44 +7,28 @@ module Diplomat
     # @param key [String] the prepared query ID
     # @param options [Hash] :dc string for dc specific query
     # @return [OpenStruct] all data associated with the prepared query
-    def get(key, options = nil)
-      url = ["/v1/query/#{key}"]
-      url += check_acl_token
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
-
-      ret = @conn.get concat_url url
+    def get(key, options = {})
+      custom_params = options[:dc] ? use_named_parameter('dc', options[:dc]) : nil
+      ret = send_get_request(@conn, ["/v1/query/#{key}"], options, custom_params)
       JSON.parse(ret.body).map { |query| OpenStruct.new query }
-    rescue Faraday::ClientError
-      raise Diplomat::QueryNotFound
     end
 
     # Get all prepared queries
     # @param options [Hash] :dc Consul datacenter to query
     # @return [OpenStruct] the list of all prepared queries
-    def get_all(options = nil)
-      url = ['/v1/query']
-      url += check_acl_token
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
-
-      ret = @conn.get concat_url url
+    def get_all(options = {})
+      custom_params = options[:dc] ? use_named_parameter('dc', options[:dc]) : nil
+      ret = send_get_request(@conn, ['/v1/query'], options, custom_params)
       JSON.parse(ret.body).map { |query| OpenStruct.new query }
-    rescue Faraday::ClientError
-      raise Diplomat::PathNotFound
     end
 
     # Create a prepared query or prepared query template
     # @param definition [Hash] Hash containing definition of prepared query
     # @param options [Hash] :dc Consul datacenter to query
     # @return [String] the ID of the prepared query created
-    def create(definition, options = nil)
-      url = ['/v1/query']
-      url += check_acl_token
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
-      @raw = @conn.post do |req|
-        req.url concat_url url
-        req.body = JSON.dump(definition)
-      end
-
+    def create(definition, options = {})
+      custom_params = options[:dc] ? use_named_parameter('dc', options[:dc]) : nil
+      @raw = send_post_request(@conn, ['/v1/query'], options, definition, custom_params)
       parse_body
     rescue Faraday::ClientError
       raise Diplomat::QueryAlreadyExists
@@ -54,12 +38,9 @@ module Diplomat
     # @param key [String] the prepared query ID
     # @param options [Hash] :dc Consul datacenter to query
     # @return [Boolean]
-    def delete(key, options = nil)
-      url = ["/v1/query/#{key}"]
-      url += check_acl_token
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
-      ret = @conn.delete concat_url url
-
+    def delete(key, options = {})
+      custom_params = options[:dc] ? use_named_parameter('dc', options[:dc]) : nil
+      ret = send_delete_request(@conn, ["/v1/query/#{key}"], options, custom_params)
       ret.status == 200
     end
 
@@ -68,16 +49,9 @@ module Diplomat
     # @param definition [Hash] Hash containing updated definition of prepared query
     # @param options [Hash] :dc Consul datacenter to query
     # @return [Boolean]
-    def update(key, definition, options = nil)
-      url = ["/v1/query/#{key}"]
-      url += check_acl_token
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
-      json_definition = JSON.dump(definition)
-      ret = @conn.put do |req|
-        req.url concat_url url
-        req.body = json_definition
-      end
-
+    def update(key, definition, options = {})
+      custom_params = options[:dc] ? use_named_parameter('dc', options[:dc]) : nil
+      ret = send_put_request(@conn, ["/v1/query/#{key}"], options, definition, custom_params)
       ret.status == 200
     end
 
@@ -89,34 +63,25 @@ module Diplomat
     #   estimated round trip time from that node
     # @option limit [Integer] to limit the size of the return list to the given number of results
     # @return [OpenStruct] the list of results from the prepared query or prepared query template
-    # rubocop:disable PerceivedComplexity, CyclomaticComplexity, AbcSize
-    def execute(key, options = nil)
-      url = ["/v1/query/#{key}/execute"]
-      url += check_acl_token
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
-      url << use_named_parameter('near', options[:near]) if options && options[:near]
-      url << use_named_parameter('limit', options[:limit]) if options && options[:limit]
-
-      ret = @conn.get concat_url url
+    # rubocop:disable PerceivedComplexity
+    def execute(key, options = {})
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
+      custom_params << use_named_parameter('near', options[:near]) if options[:near]
+      custom_params << use_named_parameter('limit', options[:limit]) if options[:limit]
+      ret = send_get_request(@conn, ["/v1/query/#{key}/execute"], options, custom_params)
       OpenStruct.new JSON.parse(ret.body)
-    rescue Faraday::ClientError
-      raise Diplomat::QueryNotFound
     end
-    # rubocop:enable PerceivedComplexity, CyclomaticComplexity, AbcSize
+    # rubocop:enable PerceivedComplexity
 
     # Get the fully rendered query template
     # @param key [String] the prepared query ID or name
     # @param options [Hash] :dc Consul datacenter to query
     # @return [OpenStruct] the list of results from the prepared query or prepared query template
-    def explain(key, options = nil)
-      url = ["/v1/query/#{key}/explain"]
-      url += check_acl_token
-      url << use_named_parameter('dc', options[:dc]) if options && options[:dc]
-
-      ret = @conn.get concat_url url
+    def explain(key, options = {})
+      custom_params = options[:dc] ? use_named_parameter('dc', options[:dc]) : nil
+      ret = send_get_request(@conn, ["/v1/query/#{key}/explain"], options, custom_params)
       OpenStruct.new JSON.parse(ret.body)
-    rescue Faraday::ClientError
-      raise Diplomat::QueryNotFound
     end
   end
 end

--- a/lib/diplomat/session.rb
+++ b/lib/diplomat/session.rb
@@ -6,18 +6,14 @@ module Diplomat
     # Create a new session
     # @param value [Object] hash or json representation of the session arguments
     # @param options [Hash] session options
-    # @param options [String] :dc datacenter to create session for
     # @return [String] The sesssion id
-    def create(value = nil, options = nil)
+    def create(value = nil, options = {})
       # TODO: only certain keys are recognised in a session create request,
       # should raise an error on others.
-      raw = @conn.put do |req|
-        url = ['/v1/session/create']
-        url += use_named_parameter('dc', options[:dc]) if options && options[:dc]
-
-        req.url concat_url url
-        req.body = (value.is_a?(String) ? value : JSON.generate(value)) unless value.nil?
-      end
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
+      data = value.is_a?(String) ? value : JSON.generate(value) unless value.nil?
+      raw = send_put_request(@conn, ['/v1/session/create'], options, data, custom_params)
       body = JSON.parse(raw.body)
       body['ID']
     end
@@ -25,74 +21,54 @@ module Diplomat
     # Destroy a session
     # @param id [String] session id
     # @param options [Hash] session options
-    # @param options [String] :dc datacenter to destroy session for
     # @return [String] Success or failure of the session destruction
-    def destroy(id, options = nil)
-      raw = @conn.put do |req|
-        url = ["/v1/session/destroy/#{id}"]
-        url += use_named_parameter('dc', options[:dc]) if options && options[:dc]
-
-        req.url concat_url url
-      end
+    def destroy(id, options = {})
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
+      raw = send_put_request(@conn, ["/v1/session/destroy/#{id}"], options, nil, custom_params)
       raw.body
     end
 
     # List sessions
     # @param options [Hash] session options
-    # @param options [String] :dc datacenter to list sessions
     # @return [OpenStruct]
-    def list(options = nil)
-      raw = @conn.get do |req|
-        url = ['/v1/session/list']
-        url += use_named_parameter('dc', options[:dc]) if options && options[:dc]
-
-        req.url concat_url url
-      end
+    def list(options = {})
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
+      raw = send_get_request(@conn, ['/v1/session/list'], options, custom_params)
       JSON.parse(raw.body).map { |session| OpenStruct.new session }
     end
 
     # Renew session
     # @param id [String] session id
     # @param options [Hash] session options
-    # @param options [String] :dc datacenter to renew session for
     # @return [OpenStruct]
-    def renew(id, options = nil)
-      raw = @conn.put do |req|
-        url = ["/v1/session/renew/#{id}"]
-        url += use_named_parameter('dc', options[:dc]) if options && options[:dc]
-
-        req.url concat_url url
-      end
+    def renew(id, options = {})
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
+      raw = send_put_request(@conn, ["/v1/session/renew/#{id}"], options, nil, custom_params)
       JSON.parse(raw.body).map { |session| OpenStruct.new session }
     end
 
     # Session information
     # @param id [String] session id
     # @param options [Hash] session options
-    # @param options [String] :dc datacenter to renew session for
     # @return [OpenStruct]
-    def info(id, options = nil)
-      raw = @conn.get do |req|
-        url = ["/v1/session/info/#{id}"]
-        url += use_named_parameter('dc', options[:dc]) if options && options[:dc]
-
-        req.url concat_url url
-      end
+    def info(id, options = {})
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
+      raw = send_get_request(@conn, ["/v1/session/info/#{id}"], options, custom_params)
       JSON.parse(raw.body).map { |session| OpenStruct.new session }
     end
 
     # Session information for a given node
     # @param name [String] node name
     # @param options [Hash] session options
-    # @param options [String] :dc datacenter to renew session for
     # @return [OpenStruct]
-    def node(name, options = nil)
-      raw = @conn.get do |req|
-        url = ["/v1/session/node/#{name}"]
-        url += use_named_parameter('dc', options[:dc]) if options && options[:dc]
-
-        req.url concat_url url
-      end
+    def node(name, options = {})
+      custom_params = []
+      custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
+      raw = send_get_request(@conn, ["/v1/session/node/#{name}"], options, custom_params)
       JSON.parse(raw.body).map { |session| OpenStruct.new session }
     end
   end

--- a/lib/diplomat/status.rb
+++ b/lib/diplomat/status.rb
@@ -4,18 +4,18 @@ module Diplomat
     @access_methods = %i[leader peers]
 
     # Get the raft leader for the datacenter in which the local consul agent is running
+    # @param options [Hash] options parameter hash
     # @return [OpenStruct] the address of the leader
-    def leader
-      url = ['/v1/status/leader']
-      ret = @conn.get concat_url url
+    def leader(options = {})
+      ret = send_get_request(@conn, ['/v1/status/leader'], options)
       JSON.parse(ret.body)
     end
 
     # Get an array of Raft peers for the datacenter in which the agent is running
+    # @param options [Hash] options parameter hash
     # @return [OpenStruct] an array of peers
-    def peers
-      url = ['/v1/status/peers']
-      ret = @conn.get concat_url url
+    def peers(options = {})
+      ret = send_get_request(@conn, ['/v1/status/peers'], options)
       JSON.parse(ret.body)
     end
   end

--- a/lib/diplomat/version.rb
+++ b/lib/diplomat/version.rb
@@ -1,3 +1,3 @@
 module Diplomat
-  VERSION = '2.0.5'.freeze
+  VERSION = '2.1.0'.freeze
 end

--- a/spec/check_spec.rb
+++ b/spec/check_spec.rb
@@ -29,7 +29,7 @@ describe Diplomat::Check do
     it 'register_script' do
       faraday.stub(:put).and_return(OpenStruct.new(body: '', status: 200))
       check = Diplomat::Check.new(faraday)
-      expect(check.register_script('foobar-1', 'Foobar', 'Foobar test', '/script/test', '10s')).to eq(true)
+      expect(check.register_script('foobar-1', 'Foobar', 'Foobar test', ['/script/test'], '10s')).to eq(true)
     end
 
     it 'register_ttl' do

--- a/spec/configure_spec.rb
+++ b/spec/configure_spec.rb
@@ -49,13 +49,13 @@ describe Diplomat do
 
       it 'Sets the correct configuration' do
         Diplomat.configure do |config|
-          config.url = 'http://google.com'
+          config.url = 'http://localhost:8500'
           config.acl_token = 'f45cbd0b-5022-47ab-8640-4eaa7c1f40f1'
           config.middleware = StubMiddleware
           config.options = { ssl: { verify: true } }
         end
 
-        expect(Diplomat.configuration.url).to eq('http://google.com')
+        expect(Diplomat.configuration.url).to eq('http://localhost:8500')
         expect(Diplomat.configuration.acl_token).to eq('f45cbd0b-5022-47ab-8640-4eaa7c1f40f1')
         expect(Diplomat.configuration.middleware).to be_a(Array)
         expect(Diplomat.configuration.middleware.first).to eq(StubMiddleware)

--- a/spec/datacenter_spec.rb
+++ b/spec/datacenter_spec.rb
@@ -3,10 +3,8 @@ require 'json'
 require 'base64'
 
 describe Diplomat::Datacenter do
-  let(:faraday) { fake }
-
   context 'datacenters' do
-    let(:key_url) { '/v1/catalog/datacenters' }
+    let(:key_url) { 'http://localhost:8500/v1/catalog/datacenters' }
     let(:body) { %w[dc1 dc2] }
     let(:headers) do
       {
@@ -20,9 +18,9 @@ describe Diplomat::Datacenter do
       it 'returns dcs' do
         json = JSON.generate(body)
 
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(body: json))
+        stub_request(:get, key_url).to_return(OpenStruct.new(body: json))
 
-        datacenters = Diplomat::Datacenter.new(faraday)
+        datacenters = Diplomat::Datacenter
 
         expect(datacenters.get.size).to eq(2)
         expect(datacenters.get.first).to eq('dc1')
@@ -33,9 +31,9 @@ describe Diplomat::Datacenter do
       it 'empty headers' do
         json = JSON.generate(body)
 
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(body: json, headers: nil))
+        stub_request(:get, key_url).to_return(OpenStruct.new(body: json, headers: nil))
 
-        datacenters = Diplomat::Datacenter.new(faraday)
+        datacenters = Diplomat::Datacenter.new
 
         meta = {}
         expect(datacenters.get(meta).size).to eq(2)
@@ -46,9 +44,10 @@ describe Diplomat::Datacenter do
       it 'filled headers' do
         json = JSON.generate(body)
 
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(body: json, headers: headers))
+        stub_request(:get, key_url)
+          .to_return(OpenStruct.new(body: json, headers: headers))
 
-        datacenters = Diplomat::Datacenter.new(faraday)
+        datacenters = Diplomat::Datacenter.new
 
         meta = {}
         s = datacenters.get(meta)

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -196,61 +196,69 @@ describe Diplomat::Event do
 
     describe 'FIRE' do
       it 'token empty' do
-        expect(faraday).to receive(:put).with("/v1/event/fire/#{event_name}", nil)
+        stub_request(:put, "http://localhost:8500/v1/event/fire/#{event_name}")
         Diplomat.configuration.acl_token = nil
-        ev = Diplomat::Event.new(faraday)
+        ev = Diplomat::Event.new
 
         ev.fire(event_name)
       end
 
       it 'token specified' do
-        expect(faraday).to receive(:put).with("/v1/event/fire/#{event_name}?token=#{acl_token}", nil)
+        stub_request(:put, "http://localhost:8500/v1/event/fire/#{event_name}")
+          .with(headers: { 'X-Consul-Token' => acl_token })
         Diplomat.configuration.acl_token = acl_token
-        ev = Diplomat::Event.new(faraday)
+        ev = Diplomat::Event.new
 
         ev.fire(event_name)
       end
     end
 
     describe 'GET_ALL' do
-      before do
-        allow(faraday).to receive(:get).and_return(OpenStruct.new(body: events_json))
-      end
-
       it 'token empty' do
-        expect(faraday).to receive(:get).with('/v1/event/list')
+        stub_without_token = stub_request(:get, 'http://localhost:8500/v1/event/list')
+                             .to_return(OpenStruct.new(body: events_json))
+        stub_with_token = stub_request(:get, 'http://localhost:8500/v1/event/list')
+                          .with(headers: { 'X-Consul-Token' => acl_token })
+                          .to_return(OpenStruct.new(body: events_json))
+
         Diplomat.configuration.acl_token = nil
-        ev = Diplomat::Event.new(faraday)
+        ev = Diplomat::Event.new
 
         ev.get_all
+        expect(stub_without_token).to have_been_requested
+        expect(stub_with_token).not_to have_been_requested
       end
 
       it 'token specified' do
-        expect(faraday).to receive(:get).with("/v1/event/list?token=#{acl_token}")
+        stub_request(:get, 'http://localhost:8500/v1/event/list')
+          .with(headers: { 'X-Consul-Token' => acl_token }).to_return(OpenStruct.new(body: events_json))
         Diplomat.configuration.acl_token = acl_token
-        ev = Diplomat::Event.new(faraday)
+        ev = Diplomat::Event.new
 
         ev.get_all
       end
     end
 
     describe 'GET' do
-      before do
-        allow(faraday).to receive(:get).and_return(OpenStruct.new(body: events_json))
-      end
-
       it 'token empty' do
-        expect(faraday).to receive(:get).with('/v1/event/list')
+        stub_without_token = stub_request(:get, 'http://localhost:8500/v1/event/list')
+                             .to_return(OpenStruct.new(body: events_json))
+        stub_with_token = stub_request(:get, 'http://localhost:8500/v1/event/list')
+                          .with(headers: { 'X-Consul-Token' => acl_token })
+                          .to_return(OpenStruct.new(body: events_json))
         Diplomat.configuration.acl_token = nil
-        ev = Diplomat::Event.new(faraday)
+        ev = Diplomat::Event.new
 
         ev.get
+        expect(stub_without_token).to have_been_requested
+        expect(stub_with_token).not_to have_been_requested
       end
 
       it 'token specified' do
-        expect(faraday).to receive(:get).with("/v1/event/list?token=#{acl_token}")
+        stub_request(:get, 'http://localhost:8500/v1/event/list')
+          .with(headers: { 'X-Consul-Token' => acl_token }).to_return(OpenStruct.new(body: events_json))
         Diplomat.configuration.acl_token = acl_token
-        ev = Diplomat::Event.new(faraday)
+        ev = Diplomat::Event.new
 
         ev.get
       end

--- a/spec/lock_spec.rb
+++ b/spec/lock_spec.rb
@@ -70,56 +70,61 @@ describe Diplomat::Lock do
 
     context 'with an ACL token configured' do
       before do
-        expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new(body: "true\n", status: 200))
         Diplomat.configure do |c|
           c.acl_token = acl_token
         end
       end
 
       it 'acquire' do
-        expect(req).to receive(:url).with("/v1/kv/lock/key?acquire=#{session}&token=#{acl_token}")
+        stub_request(:put, "http://localhost:8500/v1/kv/lock/key?acquire=#{session}")
+          .with(headers: { 'X-Consul-Token' => acl_token }).and_return(OpenStruct.new(body: "true\n", status: 200))
 
-        lock = Diplomat::Lock.new(faraday)
+        lock = Diplomat::Lock.new
 
         expect(lock.acquire('lock/key', session)).to eq(true)
       end
 
       it 'wait_to_acquire' do
-        expect(req).to receive(:url).with("/v1/kv/lock/key?acquire=#{session}&token=#{acl_token}")
+        stub_request(:put, "http://localhost:8500/v1/kv/lock/key?acquire=#{session}")
+          .with(headers: { 'X-Consul-Token' => acl_token }).and_return(OpenStruct.new(body: "true\n", status: 200))
 
-        lock = Diplomat::Lock.new(faraday)
+        lock = Diplomat::Lock.new
 
         expect(lock.wait_to_acquire('lock/key', session, 2)).to eq(true)
       end
 
       it 'release' do
-        expect(req).to receive(:url).with("/v1/kv/lock/key?release=#{session}&token=#{acl_token}")
+        stub_request(:put, "http://localhost:8500/v1/kv/lock/key?release=#{session}")
+          .with(headers: { 'X-Consul-Token' => acl_token }).and_return(OpenStruct.new(body: "true\n", status: 200))
 
-        lock = Diplomat::Lock.new(faraday)
+        lock = Diplomat::Lock.new
 
         expect(lock.release('lock/key', session).chomp).to eq('true')
       end
 
       it 'acquires with dc option' do
-        expect(req).to receive(:url).with("/v1/kv/lock/key?acquire=#{session}&token=#{acl_token}&dc=#{dc}")
+        stub_request(:put, "http://localhost:8500/v1/kv/lock/key?acquire=#{session}&dc=#{dc}")
+          .with(headers: { 'X-Consul-Token' => acl_token }).and_return(OpenStruct.new(body: "true\n", status: 200))
 
-        lock = Diplomat::Lock.new(faraday)
+        lock = Diplomat::Lock.new
 
         expect(lock.acquire('lock/key', session, nil, options)).to eq(true)
       end
 
       it 'waits to acquire with dc option' do
-        expect(req).to receive(:url).with("/v1/kv/lock/key?acquire=#{session}&token=#{acl_token}&dc=#{dc}")
+        stub_request(:put, "http://localhost:8500/v1/kv/lock/key?acquire=#{session}&dc=#{dc}")
+          .with(headers: { 'X-Consul-Token' => acl_token }).and_return(OpenStruct.new(body: "true\n", status: 200))
 
-        lock = Diplomat::Lock.new(faraday)
+        lock = Diplomat::Lock.new
 
         expect(lock.wait_to_acquire('lock/key', session, nil, 2, options)).to eq(true)
       end
 
       it 'releases with dc option' do
-        expect(req).to receive(:url).with("/v1/kv/lock/key?release=#{session}&token=#{acl_token}&dc=#{dc}")
+        stub_request(:put, "http://localhost:8500/v1/kv/lock/key?release=#{session}&dc=#{dc}")
+          .with(headers: { 'X-Consul-Token' => acl_token }).and_return(OpenStruct.new(body: "true\n", status: 200))
 
-        lock = Diplomat::Lock.new(faraday)
+        lock = Diplomat::Lock.new
 
         expect(lock.release('lock/key', session, options).chomp).to eq('true')
       end

--- a/spec/maintenance_spec.rb
+++ b/spec/maintenance_spec.rb
@@ -61,41 +61,32 @@ describe Diplomat::Maintenance do
   end
 
   context 'enable' do
-    before do
-      expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new(body: '', status: 200))
-    end
-
     it 'enables' do
-      maintenance = Diplomat::Maintenance.new(faraday)
-      expect(req).to receive(:url).with('/v1/agent/maintenance?enable=true')
+      maintenance = Diplomat::Maintenance.new
+      stub_request(:put, 'http://localhost:8500/v1/agent/maintenance?enable=true')
+        .to_return(OpenStruct.new(body: '', status: 200))
       expect(maintenance.enable(true)).to eq(true)
     end
 
     it 'disables' do
-      maintenance = Diplomat::Maintenance.new(faraday)
-      expect(req).to receive(:url).with('/v1/agent/maintenance?enable=false')
+      maintenance = Diplomat::Maintenance.new
+      stub_request(:put, 'http://localhost:8500/v1/agent/maintenance?enable=false')
+        .to_return(OpenStruct.new(body: '', status: 200))
       expect(maintenance.enable(false)).to eq(true)
     end
 
     it 'with reason' do
-      maintenance = Diplomat::Maintenance.new(faraday)
-      expect(req).to receive(:url).with('/v1/agent/maintenance?enable=true&reason=foobar')
+      maintenance = Diplomat::Maintenance.new
+      stub_request(:put, 'http://localhost:8500/v1/agent/maintenance?enable=true&reason=foobar')
+        .to_return(OpenStruct.new(body: '', status: 200))
       expect(maintenance.enable(true, 'foobar')).to eq(true)
     end
 
     it 'with dc' do
-      maintenance = Diplomat::Maintenance.new(faraday)
-      expect(req).to receive(:url).with('/v1/agent/maintenance?enable=true&reason=foobar&dc=abc')
+      maintenance = Diplomat::Maintenance.new
+      stub_request(:put, 'http://localhost:8500/v1/agent/maintenance?enable=true&reason=foobar&dc=abc')
+        .to_return(OpenStruct.new(body: '', status: 200))
       expect(maintenance.enable(true, 'foobar', dc: 'abc')).to eq(true)
-    end
-  end
-
-  context 'enable raises errors' do
-    it 'throw error unless 200' do
-      expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new(body: '', status: 500))
-      maintenance = Diplomat::Maintenance.new(faraday)
-      expect(req).to receive(:url).with('/v1/agent/maintenance?enable=true')
-      expect { maintenance.enable(true) }.to raise_error(Diplomat::UnknownStatus, 'status 500: ')
     end
   end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe Diplomat::Node do
-  let(:faraday) { fake }
-
   context 'nodes' do
     let(:node_definition) do
       {
@@ -12,14 +10,15 @@ describe Diplomat::Node do
     end
 
     describe '#register' do
-      let(:path) { '/v1/catalog/register' }
+      let(:path) { 'http://localhost:8500/v1/catalog/register' }
 
       it 'registers a node' do
         json = JSON.generate(node_definition)
 
-        faraday.stub(:put).with(path, json).and_return(OpenStruct.new(body: '', status: 200))
+        stub_request(:put, path)
+          .with(body: json).and_return(OpenStruct.new(body: '', status: 200))
 
-        node = Diplomat::Node.new(faraday)
+        node = Diplomat::Node.new
 
         n = node.register(node_definition)
         expect(n).to eq(true)
@@ -27,14 +26,15 @@ describe Diplomat::Node do
     end
 
     describe '#deregister' do
-      let(:path) { '/v1/catalog/deregister' }
+      let(:path) { 'http://localhost:8500/v1/catalog/deregister' }
 
       it 'de-registers a node' do
         json = JSON.generate(node_definition)
 
-        faraday.stub(:put).with(path, json).and_return(OpenStruct.new(body: '', status: 200))
+        stub_request(:put, path)
+          .with(body: json).and_return(OpenStruct.new(body: '', status: 200))
 
-        node = Diplomat::Node.new(faraday)
+        node = Diplomat::Node.new
 
         n = node.deregister(node_definition)
         expect(n).to eq(true)
@@ -44,8 +44,8 @@ describe Diplomat::Node do
 
   context 'services' do
     let(:key) { 'foobar' }
-    let(:key_url) { "/v1/catalog/node/#{key}" }
-    let(:all_url) { '/v1/catalog/nodes' }
+    let(:key_url) { "http://localhost:8500/v1/catalog/node/#{key}" }
+    let(:all_url) { 'http://localhost:8500/v1/catalog/nodes' }
     let(:body_all) do
       [
         {
@@ -82,7 +82,7 @@ describe Diplomat::Node do
         }
       }
     end
-    let(:all_with_dc_url) { '/v1/catalog/nodes?dc=dc1' }
+    let(:all_with_dc_url) { 'http://localhost:8500/v1/catalog/nodes?dc=dc1' }
     let(:body_all_with_dc) do
       [
         {
@@ -96,18 +96,18 @@ describe Diplomat::Node do
       it 'lists all the nodes' do
         json = JSON.generate(body_all)
 
-        faraday.stub(:get).with(all_url).and_return(OpenStruct.new(body: json))
+        stub_request(:get, all_url).and_return(OpenStruct.new(body: json))
 
-        node = Diplomat::Node.new(faraday)
+        node = Diplomat::Node.new
         expect(node.get_all.size).to eq(2)
       end
 
       it 'lists all the nodes' do
         json = JSON.generate(body_all_with_dc)
 
-        faraday.stub(:get).with(all_with_dc_url).and_return(OpenStruct.new(body: json))
+        stub_request(:get, all_with_dc_url).and_return(OpenStruct.new(body: json))
 
-        node = Diplomat::Node.new(faraday)
+        node = Diplomat::Node.new
         expect(node.get_all(dc: 'dc1').size).to eq(1)
       end
     end
@@ -116,8 +116,8 @@ describe Diplomat::Node do
       let(:cn) do
         json = JSON.generate(body)
         Diplomat.configuration.acl_token = nil
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(body: json))
-        node = Diplomat::Node.new(faraday)
+        stub_request(:get, key_url).and_return(OpenStruct.new(body: json))
+        node = Diplomat::Node.new
         node.get('foobar')
       end
 
@@ -136,27 +136,23 @@ describe Diplomat::Node do
     let(:acl_token) { 'f45cbd0b-5022-47ab-8640-4eaa7c1f40f1' }
 
     describe 'GET' do
-      # Stub Faraday's get method and return valid '{}' empty json for each parameter
-      before do
-        allow(faraday).to receive(:get).and_return(OpenStruct.new(body: '{}'))
-      end
-
       # Verify that URL passed to Faraday is without token
       it 'token empty' do
-        expect(faraday).to receive(:get).with("/v1/catalog/node/#{node_name}")
+        stub_request(:get, "http://localhost:8500/v1/catalog/node/#{node_name}").and_return(OpenStruct.new(body: '{}'))
 
         Diplomat.configuration.acl_token = nil
-        node = Diplomat::Node.new(faraday)
+        node = Diplomat::Node.new
 
         node.get(node_name)
       end
 
       # Verify that URL passed to Faraday has token from Diplomat.configuration.acl_token
       it 'token specified' do
-        expect(faraday).to receive(:get).with("/v1/catalog/node/#{node_name}?token=#{acl_token}")
+        stub_request(:get, "http://localhost:8500/v1/catalog/node/#{node_name}")
+          .with(headers: { 'X-Consul-Token' => acl_token }).and_return(OpenStruct.new(body: '{}'))
 
         Diplomat.configuration.acl_token = acl_token
-        node = Diplomat::Node.new(faraday)
+        node = Diplomat::Node.new
 
         node.get(node_name)
       end

--- a/spec/nodes_spec.rb
+++ b/spec/nodes_spec.rb
@@ -12,7 +12,7 @@ describe Diplomat::Nodes do
       }
     ]
   end
-  let(:all_datacenter_url) { "/v1/catalog/nodes?dc=#{datacenter}" }
+  let(:all_datacenter_url) { "http://localhost:8500/v1/catalog/nodes?dc=#{datacenter}" }
 
   context 'nodes' do
     it 'GET' do
@@ -39,9 +39,9 @@ describe Diplomat::Nodes do
 
     it 'GET ALL' do
       json = JSON.generate(datacenter_body_all)
-      faraday.stub(:get).with(all_datacenter_url).and_return(OpenStruct.new(body: json))
+      stub_request(:get, all_datacenter_url).and_return(OpenStruct.new(body: json))
 
-      nodes = Diplomat::Nodes.new(faraday)
+      nodes = Diplomat::Nodes.new
       options = { dc: 'us-west2' }
       expect(nodes.get_all(options).size).to eq(1)
     end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -1,17 +1,15 @@
 require 'spec_helper'
 
 describe Diplomat::Service do
-  let(:faraday) { fake }
-
   context 'services' do
     let(:key) { 'toast' }
-    let(:key_url) { "/v1/catalog/service/#{key}" }
-    let(:key_url_with_alloptions) { "/v1/catalog/service/#{key}?wait=5m&index=3&dc=somedc" }
-    let(:key_url_with_indexoption) { "/v1/catalog/service/#{key}?index=5" }
-    let(:key_url_with_waitoption) { "/v1/catalog/service/#{key}?wait=6s" }
-    let(:key_url_with_datacenteroption) { "/v1/catalog/service/#{key}?dc=somedc" }
-    let(:key_url_with_tagoption) { "/v1/catalog/service/#{key}?tag=sometag" }
-    let(:services_url_with_datacenteroption) { '/v1/catalog/services?dc=somedc' }
+    let(:key_url) { "http://localhost:8500/v1/catalog/service/#{key}" }
+    let(:key_url_with_indexoption) { "http://localhost:8500/v1/catalog/service/#{key}?index=5" }
+    let(:key_url_with_waitoption) { "http://localhost:8500/v1/catalog/service/#{key}?wait=6s" }
+    let(:key_url_with_alloptions) { "http://localhost:8500/v1/catalog/service/#{key}?wait=5m&index=3&dc=somedc" }
+    let(:key_url_with_datacenteroption) { "http://localhost:8500/v1/catalog/service/#{key}?dc=somedc" }
+    let(:key_url_with_tagoption) { "http://localhost:8500/v1/catalog/service/#{key}?tag=sometag" }
+    let(:services_url_with_datacenteroption) { 'http://localhost:8500/v1/catalog/services?dc=somedc' }
     let(:body) do
       [
         {
@@ -32,12 +30,6 @@ describe Diplomat::Service do
         }
       ]
     end
-    let(:body_all) do
-      {
-        service1: ['tag one', 'tag two', 'tag three'],
-        service2: ['tag four']
-      }
-    end
     let(:headers) do
       {
         'x-consul-index' => '8',
@@ -45,56 +37,48 @@ describe Diplomat::Service do
         'x-consul-lastcontact' => '0'
       }
     end
-
-    # Do not use ACL tokens for basic service tests
+    let(:body_all) do
+      {
+        service1: ['tag one', 'tag two', 'tag three'],
+        service2: ['tag four']
+      }
+    end
     before do
       Diplomat.configuration.acl_token = nil
     end
-
     describe 'GET' do
       it ':first' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(body: json))
-
-        service = Diplomat::Service.new(faraday)
-
+        stub_request(:get, key_url)
+          .to_return(OpenStruct.new(body: json))
+        service = Diplomat::Service.new
         expect(service.get('toast').Node).to eq('foo')
       end
-
       it ':all' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(body: json))
-
-        service = Diplomat::Service.new(faraday)
-
+        stub_request(:get, key_url)
+          .to_return(OpenStruct.new(body: json))
+        service = Diplomat::Service.new
         expect(service.get('toast', :all).size).to eq(2)
         expect(service.get('toast', :all).first.Node).to eq('foo')
       end
     end
-
     describe 'GET With Options' do
       it 'empty headers' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(body: json, headers: nil))
-
-        service = Diplomat::Service.new(faraday)
-
+        stub_request(:get, key_url)
+          .to_return(OpenStruct.new(body: json, headers: nil))
+        service = Diplomat::Service.new
         meta = {}
         s = service.get('toast', :first, {}, meta)
         expect(s.Node).to eq('foo')
         expect(meta.length).to eq(0)
       end
-
       it 'filled headers' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url).and_return(OpenStruct.new(body: json, headers: headers))
-
-        service = Diplomat::Service.new(faraday)
-
+        stub_request(:get, key_url)
+          .to_return(OpenStruct.new(body: json, headers: headers))
+        service = Diplomat::Service.new
         meta = {}
         s = service.get('toast', :first, {}, meta)
         expect(s.Node).to eq('foo')
@@ -105,11 +89,9 @@ describe Diplomat::Service do
 
       it 'index option' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url_with_indexoption).and_return(OpenStruct.new(body: json, headers: headers))
-
-        service = Diplomat::Service.new(faraday)
-
+        stub_request(:get, key_url_with_indexoption)
+          .to_return(OpenStruct.new(body: json, headers: headers))
+        service = Diplomat::Service.new
         options = { index: '5' }
         s = service.get('toast', :first, options)
         expect(s.Node).to eq('foo')
@@ -117,11 +99,9 @@ describe Diplomat::Service do
 
       it 'wait option' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url_with_waitoption).and_return(OpenStruct.new(body: json, headers: headers))
-
-        service = Diplomat::Service.new(faraday)
-
+        stub_request(:get, key_url_with_waitoption)
+          .to_return(OpenStruct.new(body: json, headers: headers))
+        service = Diplomat::Service.new
         options = { wait: '6s' }
         s = service.get('toast', :first, options)
         expect(s.Node).to eq('foo')
@@ -129,34 +109,27 @@ describe Diplomat::Service do
 
       it 'datacenter option' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url_with_datacenteroption).and_return(OpenStruct.new(body: json, headers: headers))
-
-        service = Diplomat::Service.new(faraday)
-
+        stub_request(:get, key_url_with_datacenteroption)
+          .to_return(OpenStruct.new(body: json, headers: headers))
+        service = Diplomat::Service.new
         options = { dc: 'somedc' }
         s = service.get('toast', :first, options)
         expect(s.Node).to eq('foo')
       end
 
       it 'bad datacenter option' do
-        faraday = double
-
-        allow(faraday).to receive(:get)
-          .with(key_url_with_datacenteroption)
-          .and_raise(Faraday::ClientError.new({}, 500))
-
-        service = Diplomat::Service.new(faraday)
+        stub_request(:get, key_url_with_datacenteroption)
+          .to_return(status: [500, 'Internal Server Error'])
+        service = Diplomat::Service.new
         options = { dc: 'somedc' }
         expect { service.get('toast', :first, options) }.to raise_error(Diplomat::PathNotFound)
       end
 
       it 'tag option' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url_with_tagoption).and_return(OpenStruct.new(body: json, headers: headers))
-
-        service = Diplomat::Service.new(faraday)
+        stub_request(:get, key_url_with_tagoption)
+          .to_return(OpenStruct.new(body: json, headers: headers))
+        service = Diplomat::Service.new
         options = { tag: 'sometag' }
         s = service.get('toast', :first, options)
         expect(s.Node).to eq('foo')
@@ -164,11 +137,9 @@ describe Diplomat::Service do
 
       it 'all options' do
         json = JSON.generate(body)
-
-        faraday.stub(:get).with(key_url_with_alloptions).and_return(OpenStruct.new(body: json, headers: headers))
-
-        service = Diplomat::Service.new(faraday)
-
+        stub_request(:get, key_url_with_alloptions)
+          .to_return(OpenStruct.new(body: json, headers: headers))
+        service = Diplomat::Service.new
         options = { wait: '5m', index: '3', dc: 'somedc' }
         s = service.get('toast', :first, options)
         expect(s.Node).to eq('foo')
@@ -181,10 +152,9 @@ describe Diplomat::Service do
 
       it 'lists all the services for the default datacenter' do
         json = JSON.generate(body_all)
-
-        faraday.stub(:get).and_return(OpenStruct.new(body: json))
-
-        service = Diplomat::Service.new(faraday)
+        stub_request(:get, 'http://localhost:8500/v1/catalog/services')
+          .to_return(OpenStruct.new(body: json))
+        service = Diplomat::Service.new
         expect(service.get_all.service1).to be_an(Array)
         expect(service.get_all.service2).to be_an(Array)
         expect(service.get_all.service1.first).to eq(service_one_tag)
@@ -192,11 +162,10 @@ describe Diplomat::Service do
       end
       it 'lists all the services for the specified datacenter' do
         json = JSON.generate(body_all)
-
-        faraday.stub(:get).with(services_url_with_datacenteroption).and_return(OpenStruct.new(body: json))
-
+        stub_request(:get, services_url_with_datacenteroption)
+          .to_return(OpenStruct.new(body: json))
         options = { dc: 'somedc' }
-        service = Diplomat::Service.new(faraday)
+        service = Diplomat::Service.new
         expect(service.get_all(options).service1).to be_an(Array)
         expect(service.get_all(options).service2).to be_an(Array)
         expect(service.get_all(options).service1.first).to eq(service_one_tag)
@@ -205,8 +174,8 @@ describe Diplomat::Service do
     end
 
     describe 'Register service' do
-      let(:register_service_url) { '/v1/agent/service/register' }
-      let(:deregister_service_url) { '/v1/agent/service/deregister' }
+      let(:register_service_url) { 'http://localhost:8500/v1/agent/service/register' }
+      let(:deregister_service_url) { 'http://localhost:8500/v1/agent/service/deregister' }
       let(:token) { '80a6200c-6ec9-42e1-816a-e40007e732a6' }
       let(:service_definition) do
         {
@@ -220,44 +189,39 @@ describe Diplomat::Service do
 
       it 'can register a service' do
         json_request = JSON.dump(service_definition)
-
-        expect(faraday).to receive(:put).with(register_service_url, json_request) do
-          OpenStruct.new(body: '', status: 200)
-        end
-
-        service = Diplomat::Service.new(faraday)
+        stub_request(:put, register_service_url)
+          .with(body: json_request).to_return(OpenStruct.new(body: '', status: 200))
+        service = Diplomat::Service.new
         s = service.register(service_definition)
         expect(s).to eq(true)
       end
 
       it 'can register a service with a token' do
         json_request = JSON.dump(service_definition)
-
-        expect(faraday).to receive(:put).with("#{register_service_url}?token=#{token}", json_request) do
-          OpenStruct.new(body: '', status: 200)
-        end
+        stub_request(:put, register_service_url)
+          .with(body: json_request, headers: { 'X-Consul-Token' => token })
+          .to_return(OpenStruct.new(body: '', status: 200))
         Diplomat.configure do |config|
           config.acl_token = token
         end
-        service = Diplomat::Service.new(faraday)
+        service = Diplomat::Service.new
         s = service.register(service_definition)
         expect(s).to eq(true)
       end
 
       it 'can deregister a service' do
         url = "#{deregister_service_url}/#{service_definition[:name]}"
-        expect(faraday).to receive(:put).with(url) do
-          OpenStruct.new(body: '', status: 200)
-        end
-        service = Diplomat::Service.new(faraday)
+        stub_request(:put, url)
+          .to_return(OpenStruct.new(body: '', status: 200))
+        service = Diplomat::Service.new
         s = service.deregister(service_definition[:name])
         expect(s).to eq(true)
       end
     end
 
     describe 'Register external service' do
-      let(:register_service_url) { '/v1/catalog/register' }
-      let(:deregister_service_url) { '/v1/catalog/deregister' }
+      let(:register_service_url) { 'http://localhost:8500/v1/catalog/register' }
+      let(:deregister_service_url) { 'http://localhost:8500/v1/catalog/deregister' }
 
       let(:service_definition) do
         {
@@ -280,23 +244,18 @@ describe Diplomat::Service do
 
       it 'can register a service' do
         json_request = JSON.dump(service_definition)
-
-        expect(faraday).to receive(:put).with(register_service_url, json_request) do
-          OpenStruct.new(body: '', status: 200)
-        end
-
-        service = Diplomat::Service.new(faraday)
+        stub_request(:put, register_service_url)
+          .with(body: json_request).to_return(OpenStruct.new(body: '', status: 200))
+        service = Diplomat::Service.new
         s = service.register_external(service_definition)
         expect(s).to eq(true)
       end
 
       it 'can deregister a service' do
         json_request = JSON.dump(deregister_definition)
-        expect(faraday).to receive(:put).with(deregister_service_url, json_request) do
-          OpenStruct.new(body: '', status: 200)
-        end
-
-        service = Diplomat::Service.new(faraday)
+        stub_request(:put, deregister_service_url)
+          .with(body: json_request).to_return(OpenStruct.new(body: '', status: 200))
+        service = Diplomat::Service.new
         s = service.deregister_external(deregister_definition)
         expect(s).to eq(true)
       end
@@ -304,15 +263,16 @@ describe Diplomat::Service do
 
     describe '#maintenance' do
       let(:service_id) { 'TEST1' }
-      let(:enable_url) { '/v1/agent/service/maintenance/TEST1?enable=true' }
-      let(:disable_url) { '/v1/agent/service/maintenance/TEST1?enable=false' }
+      let(:enable_url) { 'http://localhost:8500/v1/agent/service/maintenance/TEST1?enable=true' }
+      let(:disable_url) { 'http://localhost:8500/v1/agent/service/maintenance/TEST1?enable=false' }
       let(:message_url) { enable_url + '&reason=My+Maintenance+Reason' }
 
       context 'when enabling maintenance' do
         let(:s) do
           proc do |reason|
-            expect(faraday).to receive(:put).with(enable_url).and_return(OpenStruct.new(body: '', status: 200))
-            service = Diplomat::Service.new(faraday)
+            stub_request(:put, enable_url)
+              .to_return(OpenStruct.new(body: '', status: 200))
+            service = Diplomat::Service.new
             service.maintenance(service_id, enable: 'true', reason: reason)
           end
         end
@@ -327,8 +287,9 @@ describe Diplomat::Service do
 
         it 'adds a reason' do
           reason = 'My Maintenance Reason'
-          expect(faraday).to receive(:put).with(message_url).and_return(OpenStruct.new(body: '', status: 200))
-          service = Diplomat::Service.new(faraday)
+          stub_request(:put, message_url)
+            .to_return(OpenStruct.new(body: '', status: 200))
+          service = Diplomat::Service.new
           s_message = service.maintenance(service_id, enable: 'true', reason: reason)
           expect(s_message).to eq(true)
         end
@@ -337,8 +298,9 @@ describe Diplomat::Service do
       context 'when disabling maintenance' do
         let(:s) do
           proc do
-            expect(faraday).to receive(:put).with(disable_url).and_return(OpenStruct.new(body: '', status: 200))
-            service = Diplomat::Service.new(faraday)
+            stub_request(:put, disable_url)
+              .to_return(OpenStruct.new(body: '', status: 200))
+            service = Diplomat::Service.new
             service.maintenance(service_id, enable: 'false')
           end
         end
@@ -355,52 +317,62 @@ describe Diplomat::Service do
   end
 
   context 'acl' do
-    let(:acl_token) { 'f45cbd0b-5022-47ab-8640-4eaa7c1f40f1' }
-
+    let(:acl_token_1) { 'f45cbd0b-5022-47ab-8640-4eaa7c1f40f1' }
+    let(:acl_token_2) { 'f45cbd0b-5022-47ab-8640-4eaa7c1f40f2' }
     describe 'GET' do
       let(:service_name) { 'toast' }
-
-      before do
-        allow(faraday).to receive(:get).and_return(OpenStruct.new(body: '{}'))
-      end
-
       it 'token empty' do
-        expect(faraday).to receive(:get).with("/v1/catalog/service/#{service_name}")
+        stub_without_token = stub_request(:get, "http://localhost:8500/v1/catalog/service/#{service_name}")
+                             .to_return(OpenStruct.new(body: '{}'))
+        stub_with_token = stub_request(:get, "http://localhost:8500/v1/catalog/service/#{service_name}")
+                          .with(headers: { 'X-Consul-Token' => acl_token_1 }).to_return(OpenStruct.new(body: '{}'))
         Diplomat.configuration.acl_token = nil
-        service = Diplomat::Service.new(faraday)
-
+        service = Diplomat::Service.new
+        service.get(service_name)
+        expect(stub_without_token).to have_been_requested
+        expect(stub_with_token).not_to have_been_requested
+      end
+      it 'token specified in configuration' do
+        stub_request(:get, "http://localhost:8500/v1/catalog/service/#{service_name}")
+          .with(headers: { 'X-Consul-Token' => acl_token_1 }).to_return(OpenStruct.new(body: '{}'))
+        Diplomat.configuration.acl_token = acl_token_1
+        service = Diplomat::Service.new
         service.get(service_name)
       end
-
-      it 'token specified' do
-        expect(faraday).to receive(:get).with("/v1/catalog/service/#{service_name}?token=#{acl_token}")
-        Diplomat.configuration.acl_token = acl_token
-        service = Diplomat::Service.new(faraday)
-
-        service.get(service_name)
+      it 'token specified in method call' do
+        stub_request(:get, "http://localhost:8500/v1/catalog/service/#{service_name}")
+          .with(headers: { 'X-Consul-Token' => acl_token_2 }).to_return(OpenStruct.new(body: '{}'))
+        Diplomat.configuration.acl_token = acl_token_1
+        service = Diplomat::Service.new
+        service.get(service_name, :first, token: acl_token_2)
       end
     end
-
     describe 'GET_ALL' do
-      before do
-        allow(faraday).to receive(:get).and_return(OpenStruct.new(body: '{}'))
-      end
-
+      let(:service_name) { 'toast' }
       it 'token empty' do
-        expect(faraday).to receive(:get).with('/v1/catalog/services')
+        stub_without_token = stub_request(:get, 'http://localhost:8500/v1/catalog/services')
+                             .to_return(OpenStruct.new(body: '{}'))
+        stub_with_token = stub_request(:get, 'http://localhost:8500/v1/catalog/services')
+                          .with(headers: { 'X-Consul-Token' => acl_token_1 }).to_return(OpenStruct.new(body: '{}'))
         Diplomat.configuration.acl_token = nil
-        service = Diplomat::Service.new(faraday)
-
+        service = Diplomat::Service.new
+        service.get_all
+        expect(stub_without_token).to have_been_requested
+        expect(stub_with_token).not_to have_been_requested
+      end
+      it 'token specified in configuration' do
+        stub_request(:get, 'http://localhost:8500/v1/catalog/services')
+          .with(headers: { 'X-Consul-Token' => acl_token_1 }).to_return(OpenStruct.new(body: '{}'))
+        Diplomat.configuration.acl_token = acl_token_1
+        service = Diplomat::Service.new
         service.get_all
       end
-
-      it 'token specified' do
-        expect(faraday).to receive(:get).with("/v1/catalog/services?token=#{acl_token}")
-
-        Diplomat.configuration.acl_token = acl_token
-        service = Diplomat::Service.new(faraday)
-
-        service.get_all
+      it 'token specified in method call' do
+        stub_request(:get, 'http://localhost:8500/v1/catalog/services')
+          .with(headers: { 'X-Consul-Token' => acl_token_2 }).to_return(OpenStruct.new(body: '{}'))
+        Diplomat.configuration.acl_token = acl_token_1
+        service = Diplomat::Service.new
+        service.get_all(token: acl_token_2)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ end
 
 require 'diplomat'
 require 'fakes-rspec'
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true


### PR DESCRIPTION
Using the configs hash target host or token can be different at each call

e.g
value = Diplomat::Kv.get('key/path', token: '000-111-222-333-444', http_addr: 'http://consu01:8500', dc: 'dc1', stale: true)
Diplomat::Kv.put('key/path', value, token: '111-222-333-444-555', http_addr: 'http://consu02:8500', dc: 'dc2', stale: true)