### PR TITLE
Add simple tool to provide useful commands

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in roundel.gemspec
-gemspec
+gemspec name: 'diplomat'
+gemspec name: 'diplomatic_bag'

--- a/bin/consul-cli.rb
+++ b/bin/consul-cli.rb
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby
+# rubocop:disable all
+
+require 'diplomatic_bag'
+require 'optparse'
+
+def syntax
+  printf "USAGE: #{$PROGRAM_NAME} [[action]] [[options]]\n\n" \
+          "\t#{$PROGRAM_NAME} services list [options]\n" \
+          "\t#{$PROGRAM_NAME} service status <service-name> [options]\n" \
+          "\t#{$PROGRAM_NAME} info [options]\n" \
+          "\t#{$PROGRAM_NAME} nodes list-duplicate-id [options]\n\n" \
+          "Options:\n" \
+          "\t-a, --http-addr\t\tThe `address` and port of the Consul HTTP agent\n" \
+          "\t-d, --datacenter\tName of the datacenter to query\n" \
+          "\t-f, --format\t\tOutput format (json|text)\n" \
+          "\t-t, --token\t\tACL token to use in the request\n"
+  exit 0
+end
+
+def launch_query(arguments, options)
+  case arguments[0]
+  when 'services'
+    if arguments[1] == 'list'
+      DiplomaticBag.get_all_services_status(options)
+    else
+      syntax
+      exit 0
+    end
+  when 'service'
+    if arguments[1] == 'status'
+      DiplomaticBag.get_services_info(arguments[2], options)
+    else
+      syntax
+      exit 0
+    end
+  when 'info'
+    DiplomaticBag.consul_info(options)
+  when 'nodes'
+    if arguments[1] == 'list-duplicate-id'
+      DiplomaticBag.get_duplicate_node_id(options)
+    else
+      syntax
+      exit 0
+    end
+  else
+    syntax
+    exit 0
+  end
+end
+
+def parse_as_text(input, indent)
+  case input
+  when Array
+    input.each do |v|
+      parse_as_text(v, indent)
+    end
+  when Hash
+    input.each do |k, v|
+      print "#{indent}#{k}:\n"
+      parse_as_text(v, indent+'  ')
+    end
+  else
+    print "#{indent}#{input}\n"
+  end
+end
+
+options = {}
+params = {}
+output = {}
+
+OptionParser.new do |opts|
+  opts.banner = "USAGE: #{$PROGRAM_NAME} -a [[action]] [[options]]"
+
+  opts.on('-h', '--help', 'Show help') do
+    syntax
+  end
+
+  opts.on("-a", "--http-addr [CONSUL_URL]", "The `address` and port of the Consul HTTP agent") do |server|
+    options[:http_addr] = server
+  end
+
+  opts.on("-d", "--datacenter [DATACENTER]", "Name of the datacenter to query (services option)") do |dc|
+    params[:dcs] = dc
+  end
+
+  opts.on("-f", "--format TYPE", [:json, :txt], "Output format") do |format|
+    params[:format] = format
+  end
+
+  opts.on("-t", "--token [TOKEN]", "ACL token to use in the request") do |token|
+    options[:token] = token
+  end
+end.parse!
+
+if params[:dcs]
+  dcs = DiplomaticBag.get_datacenters_list(params[:dcs].split(','), options)
+  dcs.each do |dc|
+    options[:dc] = dc
+    output[dc] = launch_query(ARGV, options)
+  end
+else
+  output = launch_query(ARGV, options)
+end
+case params[:format]
+when :json
+  puts JSON.pretty_generate(output) unless output == {}
+else
+  parse_as_text(output, '') unless output == {}
+end
+
+# rubocop:enable all

--- a/diplomatic_bag.gemspec
+++ b/diplomatic_bag.gemspec
@@ -1,0 +1,13 @@
+require './lib/diplomat/version'
+
+Gem::Specification.new 'diplomatic_bag', Diplomat::VERSION do |spec|
+  spec.authors       = ['Nicolas Benoit']
+  spec.email         = ['n.benoit@criteo.com']
+  spec.description   = spec.summary = 'Toolbox for Consul'
+  spec.homepage      = 'https://github.com/WeAreFarmGeek/diplomat'
+  spec.license       = 'BSD-3-Clause'
+
+  spec.files         = `git ls-files lib README.md LICENSE features`.split("\n")
+
+  spec.add_development_dependency 'diplomat'
+end

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -58,8 +58,8 @@ module Diplomat
           # See https://bugs.ruby-lang.org/issues/10969
           begin
             super
-          rescue NameError => err
-            raise NoMethodError, err
+          rescue NameError => e
+            raise NoMethodError, e
           end
         end
       end

--- a/lib/diplomatic_bag.rb
+++ b/lib/diplomatic_bag.rb
@@ -1,0 +1,7 @@
+require 'diplomat'
+
+# Usefull usage of Diplomat lib.
+module DiplomaticBag
+  # Load all module files
+  Dir[File.join(__dir__, 'diplomatic_bag', '*.rb')].each { |file| require file }
+end

--- a/lib/diplomatic_bag/datacenters.rb
+++ b/lib/diplomatic_bag/datacenters.rb
@@ -1,0 +1,11 @@
+# Usefull usage of Diplomat lib: Datacenter functions
+module DiplomaticBag
+  def self.get_datacenters_list(dc, options = {})
+    dcs = []
+    datacenters = Diplomat::Datacenter.get(nil, options)
+    dc.each do |c|
+      dcs.concat(datacenters.select { |d| d[/#{c}/] })
+    end
+    dcs.uniq
+  end
+end

--- a/lib/diplomatic_bag/info.rb
+++ b/lib/diplomatic_bag/info.rb
@@ -1,0 +1,32 @@
+# Usefull usage of Diplomat lib: Info functions
+module DiplomaticBag
+  # rubocop:disable AbcSize
+  def self.consul_info(options = {})
+    consul_self = Diplomat::Agent.self(options)
+    puts 'Server: ' + consul_self['Config']['NodeName']
+    puts 'Datacenter: ' + consul_self['Config']['Datacenter']
+    puts 'Consul Version: ' + consul_self['Config']['Version']
+    if consul_self['Stats']['consul']['leader_addr']
+      puts 'Leader Address: ' + consul_self['Stats']['consul']['leader_addr']
+      puts 'applied_index: ' + consul_self['Stats']['raft']['applied_index']
+      puts 'commit_index: ' + consul_self['Stats']['raft']['commit_index']
+    end
+    members = Diplomat::Members.get(options)
+    servers = members.select { |member| member['Tags']['role'] == 'consul' }.sort_by { |n| n['Name'] }
+    nodes = members.select { |member| member['Tags']['role'] == 'node' }
+    leader = Diplomat::Status.leader(options).split(':')[0]
+    puts 'Servers Count: ' + servers.count.to_s
+    puts 'Nodes Count: ' + nodes.count.to_s
+    puts 'Servers:'
+    servers.map do |s|
+      if s['Tags']['role'] == 'consul'
+        if s['Addr'] == leader
+          puts '  ' + s['Name'] + ' ' + s['Addr'] + ' *Leader*'
+        else
+          puts '  ' + s['Name'] + ' ' + s['Addr']
+        end
+      end
+    end
+  end
+  # rubocop:enable AbcSize
+end

--- a/lib/diplomatic_bag/nodes.rb
+++ b/lib/diplomatic_bag/nodes.rb
@@ -1,0 +1,28 @@
+# Usefull usage of Diplomat lib: Nodes functions
+module DiplomaticBag
+  def self.get_duplicate_node_id(options = {})
+    status = {
+      1 => 'Alive',
+      2 => '?',
+      3 => 'Left',
+      4 => 'Failed'
+    }
+    result = []
+    members = Diplomat::Members.get(options)
+    grouped = members.group_by do |row|
+      [row['Tags']['id']]
+    end
+    filtered = grouped.values.select { |a| a.size > 1 }
+    filtered.each do |dup|
+      instance = {}
+      instance[:node_id] = dup[0]['Tags']['id']
+      nodes = []
+      dup.each do |inst|
+        nodes << { name: inst['Name'], status: status[inst['Status']] }
+      end
+      instance[:nodes] = nodes
+      result << instance
+    end
+    result
+  end
+end

--- a/lib/diplomatic_bag/service.rb
+++ b/lib/diplomatic_bag/service.rb
@@ -1,0 +1,20 @@
+# Usefull usage of Diplomat lib: Service functions
+module DiplomaticBag
+  def self.get_service_info(service, options = {})
+    result = {}
+    health = Diplomat::Health.service(service, options)
+    result[service] = {}
+    health.each do |h|
+      result[service][h['Node']['Node']] = {
+        'Address': h['Node']['Address'],
+        'Port': h['Service']['Port']
+      }
+      checks = {}
+      h['Checks'].each do |c|
+        checks[c['Name']] = { 'status': c['Status'], 'output': c['Output'] }
+      end
+      result[service][h['Node']['Node']]['Checks'] = checks
+    end
+    result
+  end
+end

--- a/lib/diplomatic_bag/services.rb
+++ b/lib/diplomatic_bag/services.rb
@@ -1,0 +1,31 @@
+# Usefull usage of Diplomat lib: Services functions
+module DiplomaticBag
+  def self.get_all_services_status(options = {})
+    result = {}
+    services = Diplomat::Health.state('any', options)
+    grouped_by_service = services.group_by { |h| h['ServiceName'] }.values
+    grouped_by_service.each do |s|
+      grouped_by_status = s.group_by { |h| h['Status'] }.values
+      status = {}
+      grouped_by_status.each do |state|
+        status[state[0]['Status']] = state.count
+      end
+      result[s[0]['ServiceName']] = status
+    end
+    result
+  end
+
+  def self.get_services_list(service, options = {})
+    services = Diplomat::Service.get_all(options)
+    services.to_h.keys.grep(/#{service}/)
+  end
+
+  def self.get_services_info(service, options = {})
+    result = []
+    services = get_services_list(service, options)
+    services.each do |s|
+      result << get_service_info(s.to_s, options)
+    end
+    result
+  end
+end


### PR DESCRIPTION
Diplomatic_Bag is a library that uses Diplomat to provide useful method.
consul-cli.rb is a usage of these method usable in command line.

```
USAGE: consul-cli.rb [[action]] [[options]]

	consul-cli.rb services list [options]
	consul-cli.rb service status <service-name> [options]
	consul-cli.rb info [options]
	consul-cli.rb nodes list-duplicate-id [options]

Options:
	-a, --http-addr		The `address` and port of the Consul HTTP agent
	-d, --datacenter	Name of the datacenter to query
	-f, --format		Output format (json|text)
	-t, --token		ACL token to use in the request
```