### PR TITLE
fix syntax error  '=>'  instead of colon

### DIFF
--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -177,8 +177,8 @@ module Diplomat
       consistency = []
 
       # Parse options used as header
-      headers = { 'X-Consul-Token': configuration.acl_token } if configuration.acl_token
-      headers = { 'X-Consul-Token': options[:token] } if options[:token]
+      headers = { 'X-Consul-Token' => configuration.acl_token } if configuration.acl_token
+      headers = { 'X-Consul-Token' => options[:token] } if options[:token]
 
       # Parse options used as query params
       consistency = 'stale' if options[:stale]


### PR DESCRIPTION
This syntax error breaks the whole release.