### PR TITLE
Allow providing multiple tags when get'ing a service

### DIFF
--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -18,7 +18,7 @@ module Diplomat
       if options[:tag]
         # tag can be either a String, or an array of strings
         # by splatting it is guaranteed to be an array of strings
-        tag_params = [*options[:tag]].each do |value|
+        [*options[:tag]].each do |value|
           custom_params << use_named_parameter('tag', value)
         end
       end

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -15,7 +15,13 @@ module Diplomat
       custom_params << use_named_parameter('wait', options[:wait]) if options[:wait]
       custom_params << use_named_parameter('index', options[:index]) if options[:index]
       custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
-      custom_params << use_named_parameter('tag', options[:tag]) if options[:tag]
+      if options[:tag]
+        # tag can be either a String, or an array of strings
+        # by splatting it is guaranteed to be an array of strings
+        tag_params = [*options[:tag]].each do |value|
+          custom_params << use_named_parameter('tag', value)
+        end
+      end
 
       ret = send_get_request(@conn, ["/v1/catalog/service/#{key}"], options, custom_params)
       if meta && ret.headers

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -9,7 +9,7 @@ describe Diplomat::Service do
     let(:key_url_with_alloptions) { "http://localhost:8500/v1/catalog/service/#{key}?wait=5m&index=3&dc=somedc" }
     let(:key_url_with_datacenteroption) { "http://localhost:8500/v1/catalog/service/#{key}?dc=somedc" }
     let(:key_url_with_tagoption) { "http://localhost:8500/v1/catalog/service/#{key}?tag=sometag" }
-    let(:key_url_with_multiple_tagoption) { "http://localhost:8500/v1/catalog/service/#{key}?tag=sometag&tag=anothertag" }
+    let(:key_url_with_mult_tagoption) { "http://localhost:8500/v1/catalog/service/#{key}?tag=sometag&tag=anothertag" }
     let(:services_url_with_datacenteroption) { 'http://localhost:8500/v1/catalog/services?dc=somedc' }
     let(:body) do
       [
@@ -34,9 +34,9 @@ describe Diplomat::Service do
     let(:body_one) do
       [
         {
-          'Node'        => 'bar',
-          'Address'     => '10.1.10.13',
-          'ServiceID'   => key,
+          'Node' => 'bar',
+          'Address' => '10.1.10.13',
+          'ServiceID' => key,
           'ServiceName' => key,
           'ServiceTags' => %w[sometag anothertag],
           'ServicePort' => '70457'
@@ -150,10 +150,10 @@ describe Diplomat::Service do
 
       it 'tag options, multiple tags' do
         json = JSON.generate(body_one)
-        stub_request(:get, key_url_with_multiple_tagoption)
+        stub_request(:get, key_url_with_mult_tagoption)
           .to_return(OpenStruct.new(body: json, headers: headers))
         service = Diplomat::Service.new
-        options = { tag: ['sometag', 'anothertag'] }
+        options = { tag: %w[sometag anothertag] }
         s = service.get('toast', :first, options)
         expect(s.Node).to eq('bar')
       end

--- a/spec/service_spec.rb
+++ b/spec/service_spec.rb
@@ -9,6 +9,7 @@ describe Diplomat::Service do
     let(:key_url_with_alloptions) { "http://localhost:8500/v1/catalog/service/#{key}?wait=5m&index=3&dc=somedc" }
     let(:key_url_with_datacenteroption) { "http://localhost:8500/v1/catalog/service/#{key}?dc=somedc" }
     let(:key_url_with_tagoption) { "http://localhost:8500/v1/catalog/service/#{key}?tag=sometag" }
+    let(:key_url_with_multiple_tagoption) { "http://localhost:8500/v1/catalog/service/#{key}?tag=sometag&tag=anothertag" }
     let(:services_url_with_datacenteroption) { 'http://localhost:8500/v1/catalog/services?dc=somedc' }
     let(:body) do
       [
@@ -24,6 +25,18 @@ describe Diplomat::Service do
           'Node' => 'bar',
           'Address' => '10.1.10.13',
           'ServiceID' => key,
+          'ServiceName' => key,
+          'ServiceTags' => %w[sometag anothertag],
+          'ServicePort' => '70457'
+        }
+      ]
+    end
+    let(:body_one) do
+      [
+        {
+          'Node'        => 'bar',
+          'Address'     => '10.1.10.13',
+          'ServiceID'   => key,
           'ServiceName' => key,
           'ServiceTags' => %w[sometag anothertag],
           'ServicePort' => '70457'
@@ -133,6 +146,16 @@ describe Diplomat::Service do
         options = { tag: 'sometag' }
         s = service.get('toast', :first, options)
         expect(s.Node).to eq('foo')
+      end
+
+      it 'tag options, multiple tags' do
+        json = JSON.generate(body_one)
+        stub_request(:get, key_url_with_multiple_tagoption)
+          .to_return(OpenStruct.new(body: json, headers: headers))
+        service = Diplomat::Service.new
+        options = { tag: ['sometag', 'anothertag'] }
+        s = service.get('toast', :first, options)
+        expect(s.Node).to eq('bar')
       end
 
       it 'all options' do


### PR DESCRIPTION
Hello there!

I noticed that it was not possible to request a service while passing multiple tags.

Consider for example a service like this:
```sh
consul services register -id="service-sometag-someothertag" -name "service" (...)  -tag sometag -tag someothertag
```

Consul allows you to retrieve it like this:
```sh
curl "http://localhost:8500/v1/catalog/service/service?tag=sometag&tag=someothertag"
```

This was however not supported by Diplomat, so I extended the `:tag` option to also allow an array of tags. The semantics are the same as in consul, all passed tags must match.