### PR TITLE
Allow overriding the params_encoder when making requests to consul

### DIFF
--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -198,6 +198,7 @@ module Diplomat
       url += custom_params unless custom_params.nil?
       begin
         connection.get do |req|
+          req.options[:params_encoder] = options[:params_encoder] if options[:params_encoder]
           req.url rest_options[:url_prefix] ? rest_options[:url_prefix] + concat_url(url) : concat_url(url)
           rest_options[:headers].map { |k, v| req.headers[k.to_sym] = v } unless rest_options[:headers].nil?
           req.options.timeout = options[:timeout] if options[:timeout]

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -23,6 +23,14 @@ module Diplomat
         end
       end
 
+      # We have to provide a custom params encoder here because Faraday - by default - assumes that
+      # list keys have [] as part of their name. This is however not the case for consul tags, which
+      # just use repeated occurences of the same key.
+      #
+      # So faraday reduces this: http://localhost:8500?a=1&a=2 to http://localhost:8500?a=2 unless you
+      # explicitly tell it not to.
+      options[:params_encoder] = Faraday::FlatParamsEncoder
+
       ret = send_get_request(@conn, ["/v1/catalog/service/#{key}"], options, custom_params)
       if meta && ret.headers
         meta[:index] = ret.headers['x-consul-index'] if ret.headers['x-consul-index']


### PR DESCRIPTION
I hate to be that guy, but the previous patch I submitted did not work due to an incompatibility in how Faraday works with URLs and how Consul does that.

As far as I can find, consul expects the tags variable to repeated to provide multiple tags:
```
http://localhost:8500/v1/catalog/service/my-service?tag=sometag&tag=someothertag
```

Whereas faraday (by default) expects repeated occurrences to have `[]` in their key name:
```
http://localhost:8500/v1/catalog/service/my-service?tag[]=sometag&tag[]=someothertag
```

Furthermore, if you do it the way that faraday doesn't expect but consul does, only the _last_ occurance of the key is kept, so the url actually becomes this:
```
http://localhost:8500/v1/catalog/service/my-service?tag=someothertag
```

Luckily, faraday allows overriding this behaviour by setting the `params_encoder` to `Faraday::FlatParamsEncoder`, but sadly this breaks in other parts of Diplomat. Somehow faraday then decided to change its expectation of boolean "flags" (e.g. `?myflag`) to boolean "variables" (e.g. `?myflag=true`), which I wasn't comfortable changing in the entire codebase.

Therefore I provided a way to override the params_encoder on a per-request basis, and set this option specifically for the service location. This time I verified that the request traveling to consul actually contains all tags that are supplied.

Once again, sorry for the bug.

P.s. I didn't break Diplomat, as providing a single tag still worked as expected, but the multiple tag feature I intended to add did not work...