### PR TITLE
add Diplomat::Role for Consul ACL roles in 1.5.x

### DIFF
--- a/lib/diplomat.rb
+++ b/lib/diplomat.rb
@@ -29,7 +29,7 @@ module Diplomat
   require_libs 'configuration', 'rest_client', 'kv', 'datacenter', 'service',
                'members', 'node', 'nodes', 'check', 'health', 'session', 'lock',
                'error', 'event', 'acl', 'maintenance', 'query', 'agent', 'status',
-               'policy', 'token'
+               'policy', 'token', 'role'
   self.configuration ||= Diplomat::Configuration.new
 
   class << self

--- a/lib/diplomat/error.rb
+++ b/lib/diplomat/error.rb
@@ -19,4 +19,6 @@ module Diplomat
   class AccessorIdParameterRequired < StandardError; end
   class TokenMalformed < StandardError; end
   class PolicyAlreadyExists < StandardError; end
+  class RoleMalformed < StandardError; end
+  class RoleNotFound < StandardError; end
 end

--- a/lib/diplomat/role.rb
+++ b/lib/diplomat/role.rb
@@ -1,0 +1,117 @@
+module Diplomat
+  # Methods for interacting with the Consul ACL Role API endpoint
+  class Role < Diplomat::RestClient
+    @access_methods = %i[list read create delete update]
+    attr_reader :id, :type, :acl
+
+    # Read ACL role with the given UUID or name
+    # @param id [String] UUID or name of the ACL role to read
+    # @param options [Hash] options parameter hash
+    # @return [Hash] existing ACL role
+    # rubocop:disable PerceivedComplexity
+    def read(id, options = {}, not_found = :reject, found = :return)
+      endpoint = if id =~ /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+                   "/v1/acl/role/#{id}"
+                 else
+                   "/v1/acl/role/name/#{id}"
+                 end
+      @options = options
+      custom_params = []
+      custom_params << use_consistency(options)
+
+      @raw = send_get_request(@conn_no_err, [endpoint], options, custom_params)
+
+      if @raw.status == 200 && @raw.body.chomp != 'null'
+        case found
+        when :reject
+          raise Diplomat::RoleNotFound, id
+        when :return
+          return parse_body
+        end
+      elsif @raw.status == 404
+        case not_found
+        when :reject
+          raise Diplomat::RoleNotFound, id
+        when :return
+          return nil
+        end
+      elsif @raw.status == 403
+        case not_found
+        when :reject
+          raise Diplomat::AclNotFound, id
+        when :return
+          return nil
+        end
+      else
+        raise Diplomat::UnknownStatus, "status #{@raw.status}: #{@raw.body}"
+      end
+    end
+    # rubocop:enable PerceivedComplexity
+
+    # List all the ACL roles
+    # @param options [Hash] options parameter hash
+    # @return [List] list of [Hash] of ACL roles
+    def list(options = {})
+      @raw = send_get_request(@conn_no_err, ['/v1/acl/roles'], options)
+      raise Diplomat::AclNotFound if @raw.status == 403
+
+      parse_body
+    end
+
+    # Update an existing ACL role
+    # @param value [Hash] ACL role definition, ID and Name fields are mandatory
+    # @param options [Hash] options parameter hash
+    # @return [Hash] result ACL role
+    def update(value, options = {})
+      id = value[:ID] || value['ID']
+      raise Diplomat::IdParameterRequired if id.nil?
+
+      role_name = value[:Name] || value['Name']
+      raise Diplomat::NameParameterRequired if role_name.nil?
+
+      custom_params = use_cas(@options)
+      @raw = send_put_request(@conn, ["/v1/acl/role/#{id}"], options, value, custom_params)
+      if @raw.status == 200
+        parse_body
+      elsif @raw.status == 400
+        raise Diplomat::RoleMalformed, @raw.body
+      else
+        raise Diplomat::UnknownStatus, "status #{@raw.status}: #{@raw.body}"
+      end
+    end
+
+    # Create a new ACL role
+    # @param value [Hash] ACL role definition, Name field is mandatory
+    # @param options [Hash] options parameter hash
+    # @return [Hash] new ACL role
+    def create(value, options = {})
+      blacklist = ['ID', 'iD', 'Id', :ID, :iD, :Id] & value.keys
+      raise Diplomat::RoleMalformed, 'ID should not be specified' unless blacklist.empty?
+
+      id = value[:Name] || value['Name']
+      raise Diplomat::NameParameterRequired if id.nil?
+
+      custom_params = use_cas(@options)
+      @raw = send_put_request(@conn, ['/v1/acl/role'], options, value, custom_params)
+
+      # rubocop:disable GuardClause
+      if @raw.status == 200
+        return parse_body
+      elsif @raw.status == 500 && @raw.body.chomp.include?('already exists')
+        raise Diplomat::RoleAlreadyExists, @raw.body
+      else
+        raise Diplomat::UnknownStatus, "status #{@raw.status}: #{@raw.body}"
+      end
+    end
+    # rubocop:enable GuardClause
+
+    # Delete an ACL role by its UUID
+    # @param id [String] UUID of the ACL role to delete
+    # @param options [Hash] options parameter hash
+    # @return [Bool]
+    def delete(id, options = {})
+      @raw = send_delete_request(@conn, ["/v1/acl/role/#{id}"], options, nil)
+      @raw.body.chomp == 'true'
+    end
+  end
+end

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Diplomat::Policy do
-  context 'Consul 1.4.x' do
+  context 'Consul 1.4+' do
     let(:key_url) { 'http://localhost:8500/v1/acl' }
     let(:id) { '2c9e66bd-9b67-ef5b-34ac-38901e792646' }
     let(:read_body) do

--- a/spec/role_spec.rb
+++ b/spec/role_spec.rb
@@ -1,0 +1,168 @@
+require 'spec_helper'
+
+describe Diplomat::Role do
+  context 'Consul 1.5+' do
+    let(:key_url) { 'http://localhost:8500/v1/acl' }
+    let(:id) { '4fcb8566-07b3-4deb-8c1b-393d31c16dd6' }
+    let(:name) { 'test' }
+    let(:read_body) do
+      [
+        {
+          'ID' => id,
+          'Name' => 'test',
+          'Description' => 'Test role',
+          'Hash' => 'WIDzFAz18+8f+V1auNnrWdXiyZTrDWtKnzL/7OXXvYM=',
+          'CreateIndex' => 42,
+          'ModifyIndex' => 4242,
+          'Policies' => [
+            { "ID": '783beef3-783f-f41f-7422-7087dc272765' },
+            { "Name": 'node-read' }
+          ],
+          "ServiceIdentities": [
+            { "ServiceName": 'web' },
+            {
+              "ServiceName": 'db',
+              "Datacenters": [
+                'dc1'
+              ]
+            }
+          ]
+        }
+      ]
+    end
+    let(:list_body) do
+      [
+        read_body,
+        {
+          "ID": '5e52a099-4c90-c067-5478-980f06be9af5',
+          "Name": 'node-read',
+          "Description": '',
+          "Policies": [
+            {
+              "ID": '783beef3-783f-f41f-7422-7087dc272765',
+              "Name": 'node-read'
+            }
+          ],
+          "Hash": 'K6AbfofgiZ1BEaKORBloZf7WPdg45J/PipHxQiBlK1U=',
+          "CreateIndex": 50,
+          "ModifyIndex": 50
+        }
+      ]
+    end
+
+    describe 'read' do
+      it 'returns an existing ACL role if passing an UUID' do
+        json = JSON.generate(read_body)
+
+        url = key_url + '/role/' + id
+        stub_request(:get, url).to_return(OpenStruct.new(body: json, status: 200))
+
+        role = Diplomat::Role.new
+        role_info = role.read(id)
+
+        expect(role_info.size).to eq(1)
+        expect(role_info.first['Name']).to eq('test')
+      end
+
+      it 'returns an existing ACL role if passing a name' do
+        json = JSON.generate(read_body)
+
+        url = key_url + '/role/name/' + name
+        stub_request(:get, url).to_return(OpenStruct.new(body: json, status: 200))
+
+        role = Diplomat::Role.new
+        role_info = role.read(name)
+
+        expect(role_info.size).to eq(1)
+        expect(role_info.first['Name']).to eq('test')
+      end
+
+      it 'raises an error if ACL role name does not exist' do
+        json = 'null'
+
+        url = key_url + '/role/name/' + 'none'
+        stub_request(:get, url).to_return(OpenStruct.new(body: json, status: 404))
+
+        role = Diplomat::Role.new
+
+        expect { role.read('none') }.to raise_error(Diplomat::RoleNotFound)
+      end
+
+      it 'raises an error if ACL role UUID does not exist' do
+        json = 'null'
+
+        url = key_url + '/role/' + '86f16056-1289-4ae2-bea0-8e1bf9128866'
+        stub_request(:get, url).to_return(OpenStruct.new(body: json, status: 404))
+
+        role = Diplomat::Role.new
+
+        expect { role.read('86f16056-1289-4ae2-bea0-8e1bf9128866') }.to raise_error(Diplomat::RoleNotFound)
+      end
+    end
+
+    describe 'list' do
+      it 'returns all ACL roles' do
+        json = JSON.generate(list_body)
+
+        url = key_url + '/roles'
+        stub_request(:get, url).to_return(OpenStruct.new(body: json, status: 200))
+
+        role = Diplomat::Role.new
+        list = role.list
+
+        expect(list.size).to eq(2)
+      end
+    end
+
+    describe 'update' do
+      it 'returns the updated ACL role' do
+        json = JSON.generate(read_body.first)
+
+        url = key_url + '/role/' + id
+        stub_request(:put, url).to_return(OpenStruct.new(body: json, status: 200))
+
+        role = Diplomat::Role.new
+        response = role.update(read_body.first)
+
+        expect(response['ID']).to eq(read_body.first['ID'])
+      end
+
+      it 'fails if no ID is provided' do
+        role = Diplomat::Role.new
+        expect { role.update(Description: 'test', Name: 'test') }.to raise_error(Diplomat::IdParameterRequired)
+      end
+
+      it 'fails if no Name is provided' do
+        role = Diplomat::Role.new
+        expect { role.update(ID: 'test') }.to raise_error(Diplomat::NameParameterRequired)
+      end
+    end
+
+    describe 'create' do
+      it 'returns the ACL Role' do
+        json = JSON.generate(read_body.first.tap { |h| h.delete('ID') })
+
+        url = key_url + '/role'
+        stub_request(:put, url)
+          .with(body: json).to_return(OpenStruct.new(body: json, status: 200))
+
+        role = Diplomat::Role.new
+        response = role.create(read_body.first)
+
+        expect(response['ID']).to eq(read_body.first['ID'])
+      end
+    end
+
+    describe 'delete' do
+      it 'returns true with 200 OK' do
+        url = key_url + '/role/' + id
+        stub_request(:delete, url).to_return(OpenStruct.new(body: "true\n", status: 200))
+
+        role = Diplomat::Role.new
+        response = role.delete(id)
+
+        expect(response).to be true
+      end
+    end
+  end
+end

--- a/spec/role_spec.rb
+++ b/spec/role_spec.rb
@@ -64,6 +64,19 @@ describe Diplomat::Role do
         expect(role_info.first['Name']).to eq('test')
       end
 
+      it 'raises an error if ACL role UUID does not exist' do
+        json = 'null'
+
+        url = key_url + '/role/' + '86f16056-1289-4ae2-bea0-8e1bf9128866'
+        stub_request(:get, url).to_return(OpenStruct.new(body: json, status: 404))
+
+        role = Diplomat::Role.new
+
+        expect { role.read('86f16056-1289-4ae2-bea0-8e1bf9128866') }.to raise_error(Diplomat::RoleNotFound)
+      end
+    end
+
+    describe 'read_name' do
       it 'returns an existing ACL role if passing a name' do
         json = JSON.generate(read_body)
 
@@ -71,7 +84,7 @@ describe Diplomat::Role do
         stub_request(:get, url).to_return(OpenStruct.new(body: json, status: 200))
 
         role = Diplomat::Role.new
-        role_info = role.read(name)
+        role_info = role.read_name(name)
 
         expect(role_info.size).to eq(1)
         expect(role_info.first['Name']).to eq('test')
@@ -85,18 +98,7 @@ describe Diplomat::Role do
 
         role = Diplomat::Role.new
 
-        expect { role.read('none') }.to raise_error(Diplomat::RoleNotFound)
-      end
-
-      it 'raises an error if ACL role UUID does not exist' do
-        json = 'null'
-
-        url = key_url + '/role/' + '86f16056-1289-4ae2-bea0-8e1bf9128866'
-        stub_request(:get, url).to_return(OpenStruct.new(body: json, status: 404))
-
-        role = Diplomat::Role.new
-
-        expect { role.read('86f16056-1289-4ae2-bea0-8e1bf9128866') }.to raise_error(Diplomat::RoleNotFound)
+        expect { role.read_name('none') }.to raise_error(Diplomat::RoleNotFound)
       end
     end
 


### PR DESCRIPTION
Consul 1.5.0 introduced a number of changes (https://github.com/hashicorp/consul/blob/master/CHANGELOG.md#150-may-08-2019):

- ability to specify `AccessorID` and `SecretID` (need valid UUIDs though)
- ability to bind policies to roles (`Diplomat::Role` is added here)

This PR fixes the issue #195.

I'll open an issue for `ACL Auth Method HTTP API` and `ACL Binding Rule HTTP API` support but it won't be covered in this PR as I don't have access to a k8s cluster right now.

**Please do not merge this PR until `WIP` is removed from subject as testing is in progress.**

Thanks for reviewing it @pierresouchay 🇫🇷 