### PR TITLE
Trim leading slashes from keys in more places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Support Consul 1.4.x ACLs
 
 * add test for token creation with a specific AccessorID
 
+* Strip leading slashes from keys in API requests
+
 ## 2.2.4
 
 Now diplomatic_bag installs cleanly from rubygems.org

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -42,12 +42,8 @@ module Diplomat
     #   - W W - get the first or next value; wait until there is an update
     # rubocop:disable PerceivedComplexity, MethodLength, LineLength, CyclomaticComplexity
     def get(key, options = {}, not_found = :reject, found = :return)
-      key_subst = if key.start_with? '/'
-                    key[1..-1]
-                  else
-                    key.freeze
-                  end
-      @key = key_subst
+      key = normalize_key_for_uri(key)
+      @key = key
       @options = options
       custom_params = []
       custom_params << recurse_get(@options)
@@ -111,6 +107,7 @@ module Diplomat
     # @option options [String] :acquire Session to attach to key
     # @return [Bool] Success or failure of the write (can fail in c-a-s mode)
     def put(key, value, options = {})
+      key = normalize_key_for_uri(key)
       @options = options
       custom_params = []
       custom_params << use_cas(@options)
@@ -132,6 +129,7 @@ module Diplomat
     # @option options [Boolean] :recurse If to make recursive get or not
     # @return [OpenStruct]
     def delete(key, options = {})
+      key = normalize_key_for_uri(key)
       @key = key
       @options = options
       custom_params = []

--- a/lib/diplomat/lock.rb
+++ b/lib/diplomat/lock.rb
@@ -10,6 +10,7 @@ module Diplomat
     # @param options [Hash] options parameter hash
     # @return [Boolean] If the lock was acquired
     def acquire(key, session, value = nil, options = {})
+      key = normalize_key_for_uri(key)
       custom_params = []
       custom_params << use_named_parameter('acquire', session)
       custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
@@ -42,6 +43,7 @@ module Diplomat
     # @return [nil]
     # rubocop:disable AbcSize
     def release(key, session, options = {})
+      key = normalize_key_for_uri(key)
       custom_params = []
       custom_params << use_named_parameter('release', session)
       custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]


### PR DESCRIPTION
The same was done for GET in 58fff34c6072d21519512dbaefb4d0c46aa11ac9
but wasn't applied across the board.