### PR TITLE
adds get_all method

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,26 @@ Diplomat::Kv.get('foo/', recurse: true)
 # => [{:key=>"foo/a", :value=>"lorem"}, {:key=>"foo/b", :value=>"ipsum"}, {:key=>"foo/c", :value=>"dolor"}]
 ```
 
+You can also use `get_all` to retrieve values recursively with a consistent return type:
+
+```ruby
+Diplomat::Kv.put('foo/a', 'lorem')
+Diplomat::Kv.put('foo/b', 'ipsum')
+Diplomat::Kv.put('foo/c', 'dolor')
+
+Diplomat::Kv.get('foo/', recurse: true)
+# => [{:key=>"foo/a", :value=>"lorem"}, {:key=>"foo/b", :value=>"ipsum"}, {:key=>"foo/c", :value=>"dolor"}]
+Diplomat::Kv.get_all('foo/')
+# => [{:key=>"foo/a", :value=>"lorem"}, {:key=>"foo/b", :value=>"ipsum"}, {:key=>"foo/c", :value=>"dolor"}]
+
+Diplomat::Kv.put('bar/a', 'lorem')
+
+Diplomat::Kv.get('bar/', recurse: true)
+# => "lorem"
+Diplomat::Kv.get_all('bar/')
+# => [{:key=>"bar/a", :value=>"lorem"}]
+```
+
 
 Or list all available keys:
 

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -1,7 +1,7 @@
 module Diplomat
   # Methods for interacting with the Consul KV API endpoint
   class Kv < Diplomat::RestClient
-    @access_methods = %i[get put delete txn]
+    @access_methods = %i[get get_all put delete txn]
     attr_reader :key, :value, :raw
 
     # Get a value by its key, potentially blocking for the first or next value
@@ -18,7 +18,7 @@ module Diplomat
     #   Only applies when combined with :keys option.
     # @option options [Boolean] :nil_values If to return keys/dirs with nil values
     # @option options [Boolean] :convert_to_hash Take the data returned from consul and build a hash
-    # @option options [Callable] :transformation funnction to invoke on keys values
+    # @option options [Callable] :transformation function to invoke on keys values
     # @param not_found [Symbol] behaviour if the key doesn't exist;
     #   :reject with exception, :return degenerate value, or :wait for it to appear
     # @param found [Symbol] behaviour if the key does exist;
@@ -42,20 +42,11 @@ module Diplomat
     #   - W W - get the first or next value; wait until there is an update
     # rubocop:disable PerceivedComplexity, MethodLength, LineLength, CyclomaticComplexity
     def get(key, options = {}, not_found = :reject, found = :return)
-      key = normalize_key_for_uri(key)
-      @key = key
       @options = options
-      custom_params = []
-      custom_params << recurse_get(@options)
-      custom_params << use_consistency(options)
-      custom_params << dc(@options)
-      custom_params << keys(@options)
-      custom_params << separator(@options)
-
       return_nil_values = @options && @options[:nil_values]
       transformation = @options && @options[:transformation] && @options[:transformation].methods.find_index(:call) ? @options[:transformation] : nil
+      raw = get_raw(key, options)
 
-      raw = send_get_request(@conn_no_err, ["/v1/kv/#{@key}"], options, custom_params)
       if raw.status == 404
         case not_found
         when :reject
@@ -86,17 +77,70 @@ module Diplomat
       end
 
       # Wait for first/next value
-      custom_params << use_named_parameter('index', index)
-      if options.nil?
-        options = { timeout: 86_400 }
-      else
-        options[:timeout] = 86_400
-      end
-      @raw = send_get_request(@conn, ["/v1/kv/#{@key}"], options, custom_params)
+      @raw = wait_for_value(index, options)
       @raw = parse_body
       return_value(return_nil_values, transformation)
     end
     # rubocop:enable PerceivedComplexity, LineLength, MethodLength, CyclomaticComplexity
+
+    # Get all keys recursively, potentially blocking for the first or next value
+    # @param key [String] the key
+    # @param options [Hash] the query params
+    # @option options [String] :consistency The read consistency type
+    # @option options [String] :dc Target datacenter
+    # @option options [Boolean] :keys Only return key names.
+    # @option options [Boolean] :decode_values Return consul response with decoded values.
+    # @option options [String] :separator List only up to a given separator.
+    #   Only applies when combined with :keys option.
+    # @option options [Boolean] :nil_values If to return keys/dirs with nil values
+    # @option options [Boolean] :convert_to_hash Take the data returned from consul and build a hash
+    # @option options [Callable] :transformation function to invoke on keys values
+    # @param not_found [Symbol] behaviour if the key doesn't exist;
+    #   :reject with exception, :return degenerate value, or :wait for it to appear
+    # @param found [Symbol] behaviour if the key does exist;
+    #   :reject with exception, :return its current value, or :wait for its next value
+    # @return [List] List of hashes, one hash for each key-value returned
+    # rubocop:disable PerceivedComplexity, MethodLength, LineLength, CyclomaticComplexity
+    def get_all(key, options = {}, not_found = :reject, found = :return)
+      @options = options
+      @options[:recurse] = true
+      return_nil_values = @options && @options[:nil_values]
+      transformation = @options && @options[:transformation] && @options[:transformation].methods.find_index(:call) ? @options[:transformation] : nil
+
+      raw = get_raw(key, options)
+      if raw.status == 404
+        case not_found
+        when :reject
+          raise Diplomat::KeyNotFound, key
+        when :return
+          return @value = ''
+        when :wait
+          index = raw.headers['x-consul-index']
+        end
+      elsif raw.status == 200
+        case found
+        when :reject
+          raise Diplomat::KeyAlreadyExists, key
+        when :return
+          @raw = raw
+          @raw = parse_body
+          return decode_values if @options && @options[:decode_values]
+          return convert_to_hash(return_value(return_nil_values, transformation, true)) if @options && @options[:convert_to_hash]
+
+          return return_value(return_nil_values, transformation, true)
+        when :wait
+          index = raw.headers['x-consul-index']
+        end
+      else
+        raise Diplomat::UnknownStatus, "status #{raw.status}: #{raw.body}"
+      end
+
+      # Wait for first/next value
+      @raw = wait_for_value(index, options)
+      @raw = parse_body
+      return_value(return_nil_values, transformation, true)
+    end
+    # rubocop:enable PerceivedComplexity, MethodLength, LineLength, CyclomaticComplexity
 
     # Associate a value with a key
     # @param key [String] the key
@@ -171,6 +215,31 @@ module Diplomat
     end
 
     private
+
+    def get_raw(key, options = {}, custom_params = nil)
+      key = normalize_key_for_uri(key)
+      @key = key
+      @options = options
+      custom_params = []
+      custom_params << recurse_get(@options)
+      custom_params << use_consistency(@options)
+      custom_params << dc(@options)
+      custom_params << keys(@options)
+      custom_params << separator(@options)
+
+      send_get_request(@conn_no_err, ["/v1/kv/#{@key}"], options, custom_params)
+    end
+
+    def wait_for_value(index, options)
+      custom_params = []
+      custom_params << use_named_parameter('index', index)
+      if options.nil?
+        options = { timeout: 86_400 }
+      else
+        options[:timeout] = 86_400
+      end
+      get_raw(key, options, custom_params)
+    end
 
     def recurse_get(options)
       options[:recurse] ? ['recurse'] : []

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -113,7 +113,7 @@ module Diplomat
         when :reject
           raise Diplomat::KeyNotFound, key
         when :return
-          return @value = ''
+          return @value = []
         when :wait
           index = raw.headers['x-consul-index']
         end
@@ -216,11 +216,10 @@ module Diplomat
 
     private
 
-    def get_raw(key, options = {}, custom_params = nil)
+    def get_raw(key, options = {}, custom_params = [])
       key = normalize_key_for_uri(key)
       @key = key
       @options = options
-      custom_params = []
       custom_params << recurse_get(@options)
       custom_params << use_consistency(@options)
       custom_params << dc(@options)

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -356,6 +356,78 @@ describe Diplomat::Kv do
       end
     end
 
+    describe '#get_all' do
+      context 'normal context' do
+        it 'GET_ALL' do
+          kv = Diplomat::Kv.new
+          stub_request(:get, 'http://localhost:8500/v1/kv/foo?recurse')
+            .to_return(OpenStruct.new(status: 200, body: JSON.generate([])))
+          kv.get_all('foo')
+        end
+      end
+
+      context 'Datacenter filter' do
+        it 'GET_ALL for a specific datacenter' do
+          kv = Diplomat::Kv.new
+          stub_request(:get, 'http://localhost:8500/v1/kv/foo?dc=bar&recurse')
+            .to_return(OpenStruct.new(status: 200, body: JSON.generate([])))
+          kv.get_all('foo', dc: 'bar')
+        end
+      end
+
+      context 'recursive get returns only a single result' do
+        let(:json) do
+          JSON.generate(
+            [
+              {
+                'Key' => key + 'foo',
+                'Value' => Base64.encode64(key_params),
+                'Flags' => 0
+              }
+            ]
+          )
+        end
+
+        it 'GET_ALL and returns a single item list' do
+          faraday.stub(:get).and_return(OpenStruct.new(status: 200, body: json))
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.get_all(key)).to eql(
+            [
+              { key: key + 'foo', value: 'toast' }
+            ]
+          )
+        end
+      end
+
+      context 'supports convert_to_hash option' do
+        let(:json) do
+          JSON.generate(
+            [
+              {
+                'Key' => key + 'foo',
+                'Value' => Base64.encode64(key_params),
+                'Flags' => 0
+              },
+              {
+                'Key' => key + 'i/am/nested',
+                'Value' => Base64.encode64(key_params),
+                'Flags' => 0
+              }
+            ]
+          )
+        end
+
+        it 'GET_ALL and returns a Hash' do
+          faraday.stub(:get).and_return(OpenStruct.new(status: 200, body: json))
+          kv = Diplomat::Kv.new(faraday)
+          expect(kv.get_all(key, convert_to_hash: true)).to eql({
+            key + 'foo' => 'toast',
+            key + 'i' => {"am"=>{"nested"=>"toast"}}
+          })
+        end
+      end
+    end
+
     describe '#put' do
       context 'ACLs NOT enabled' do
         it 'PUT' do


### PR DESCRIPTION
Adds `get_all` method to KV class to provide consistent behavior and return types when recursively retrieving keys. The specific issue raised in #162 is that `get('foo', recurse: true)` returns just the value if there is only one key returned. `get_all('foo')` will always return an Array regardless of number of results. The `convert_to_hash` option is also supported.

As the new method shares a lot of the same logic as `get`, I moved certain functionality into new common methods invoked by both `get` and `get_all` to avoid duplicating the same code in two spots.

Fixes #162 