### PR TITLE
support faraday 1.0.0

### DIFF
--- a/diplomat.gemspec
+++ b/diplomat.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new 'diplomat', Diplomat::VERSION do |spec|
 
   spec.add_runtime_dependency 'deep_merge', '~> 1.0', '>= 1.0.1'
   # NOTE not tested on faraday 1.0.0
-  spec.add_runtime_dependency 'faraday', '>= 0.9', '< 1.0.0'
+  spec.add_runtime_dependency 'faraday', '>= 0.9', '< 2.0.0'
   spec.add_runtime_dependency 'json_pure' if RUBY_VERSION < '1.9.3'
 end

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -241,7 +241,7 @@ module Diplomat
           rest_options[:headers].map { |k, v| req.headers[k.to_sym] = v } unless rest_options[:headers].nil?
           req.options.timeout = options[:timeout] if options[:timeout]
         end
-      rescue Faraday::ClientError => e
+      rescue Faraday::ClientError, Faraday::ServerError => e
         resp = e.response
         if resp
           raise Diplomat::AclNotFound, e if resp[:status] == 403 && resp[:body] == 'ACL not found'


### PR DESCRIPTION
I ran in to a gem conflict with the latest release of Chef Infra Client since they are now using faraday 1.0.0 in their bundled ruby. Reading the [upgrade guide for faraday](https://github.com/lostisland/faraday/blob/master/UPGRADING.md#errors), it seems like this may be the only fix needed to get the current version of diplomat working with faraday 1.0.0

This change passes `rake` using both faraday 1.0.0 and 0.17.3 