### PR TITLE
Avoid `Hash#deep_merge` monkeypatch

### DIFF
--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'deep_merge'
+require 'deep_merge/core'
 
 module Diplomat
   # Base class for interacting with the Consul RESTful API
@@ -146,9 +146,12 @@ module Diplomat
 
     # Converts k/v data into ruby hash
     def convert_to_hash(data)
-      data.map do |item|
+      data_h = data.map do |item|
         item[:key].split('/').reverse.reduce(item[:value]) { |h, v| { v => h } }
-      end.reduce(:deep_merge)
+      end
+      data_h.reduce({}) do |dest, source|
+        DeepMerge.deep_merge!(source, dest, { preserve_unmergeables: true })
+      end
     end
 
     # Parse the body, apply it to the raw attribute

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -157,6 +157,7 @@ describe Diplomat::Kv do
           answer['foo'] = 'bar'
           expect(kv.get(key, recurse: true, convert_to_hash: true)).to eql(answer)
         end
+
         it 'GET with nil values' do
           faraday.stub(:get).and_return(OpenStruct.new(status: 200, body: json))
           kv = Diplomat::Kv.new(faraday)


### PR DESCRIPTION
As of https://github.com/WeAreFarmGeek/diplomat/pull/176, `require 'diplomat'` also calls `require 'deep_merge'`, which monkey-patches `Hash#deep_merge`. This is unnecessary – Diplomat could `require 'deep_merge/core` and call `DeepMerge.deep_merge!` directly. This is important for codebases that are sensitive to core monkey-patches.

Thank you