### PR TITLE
Add multiple tag suppport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## Next
 
+* Added ability to specify multiple tags when requesting checks for a service
+* Generalized the Faraday params encoder to always use `FlatParamsEncoder` to match
+  the expectations of the Consul API
+
 ## 2.4.2
 
 * Fix faraday to version lower than 1.1.0 to keep ruby support for old versions of Consul #211
 * Added ability to specify 'cached' as a query option
-* Added support for node-meta param to specify node level tags when queying for service health. 
+* Added support for node-meta param to specify node level tags when queying for service health.
   eg Diplomat::Health.service('apache', passing: true, node_meta: "rack:rack-2")
   see https://www.consul.io/docs/agent/options#node_meta for more info on setting tags
 

--- a/lib/diplomat/health.rb
+++ b/lib/diplomat/health.rb
@@ -39,7 +39,7 @@ module Diplomat
       custom_params = []
       custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
       custom_params << ['passing'] if options[:passing]
-      custom_params << use_named_parameter('tag', options[:tag]) if options[:tag]
+      custom_params += [*options[:tag]].map { |value| use_named_parameter('tag', value) } if options[:tag]
       custom_params << use_named_parameter('near', options[:near]) if options[:near]
       custom_params << use_named_parameter('node-meta', options[:node_meta]) if options[:node_meta]
 

--- a/lib/diplomat/rest_client.rb
+++ b/lib/diplomat/rest_client.rb
@@ -140,6 +140,14 @@ module Diplomat
         faraday.request  :url_encoded
         faraday.response :raise_error unless raise_error
 
+        # We have to provide a custom params encoder here because Faraday - by default - assumes that
+        # list keys have [] as part of their name. This is however does not match the expectation of
+        # the Consul API, which assumes the same query param to simply be repeated
+        #
+        # So faraday reduces this: http://localhost:8500?a=1&a=2 to http://localhost:8500?a=2 unless you
+        # explicitly tell it not to.
+        faraday.options[:params_encoder] = Faraday::FlatParamsEncoder
+
         faraday.adapter  Faraday.default_adapter
       end
     end

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -25,14 +25,6 @@ module Diplomat
         end
       end
 
-      # We have to provide a custom params encoder here because Faraday - by default - assumes that
-      # list keys have [] as part of their name. This is however not the case for consul tags, which
-      # just use repeated occurences of the same key.
-      #
-      # So faraday reduces this: http://localhost:8500?a=1&a=2 to http://localhost:8500?a=2 unless you
-      # explicitly tell it not to.
-      options[:params_encoder] = Faraday::FlatParamsEncoder
-
       ret = send_get_request(@conn, ["/v1/catalog/service/#{key}"], options, custom_params)
       if meta && ret.headers
         meta[:index] = ret.headers['x-consul-index'] if ret.headers['x-consul-index']

--- a/lib/diplomat/service.rb
+++ b/lib/diplomat/service.rb
@@ -17,13 +17,7 @@ module Diplomat
       custom_params << use_named_parameter('wait', options[:wait]) if options[:wait]
       custom_params << use_named_parameter('index', options[:index]) if options[:index]
       custom_params << use_named_parameter('dc', options[:dc]) if options[:dc]
-      if options[:tag]
-        # tag can be either a String, or an array of strings
-        # by splatting it is guaranteed to be an array of strings
-        [*options[:tag]].each do |value|
-          custom_params << use_named_parameter('tag', value)
-        end
-      end
+      custom_params += [*options[:tag]].map { |value| use_named_parameter('tag', value) } if options[:tag]
 
       ret = send_get_request(@conn, ["/v1/catalog/service/#{key}"], options, custom_params)
       if meta && ret.headers

--- a/spec/health_spec.rb
+++ b/spec/health_spec.rb
@@ -197,6 +197,14 @@ describe Diplomat::Health do
       expect(health.service('foobar', options: options).first['Node']['Node']).to eq('foobar')
     end
 
+    it 'check service with multiple tag options' do
+      stub_request(:get, "http://localhost:8500/v1/health/service/foobar?tag=v1&tag=v2")
+        .and_return(body: json)
+      health = Diplomat::Health
+
+      expect(health.service('foobar', tag: ['v1', 'v2']).first['Node']['Node']).to eq('foobar')
+    end
+
     it 'should check service with node-meta option' do
       faraday.stub(:get).and_return(OpenStruct.new(body: json))
       health = Diplomat::Health.new(faraday)

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -363,7 +363,7 @@ describe Diplomat::Kv do
       context 'normal context' do
         it 'GET_ALL' do
           kv = Diplomat::Kv.new
-          stub_request(:get, 'http://localhost:8500/v1/kv/foo?recurse')
+          stub_request(:get, 'http://localhost:8500/v1/kv/foo?recurse=true')
             .to_return(OpenStruct.new(status: 200, body: JSON.generate([])))
           kv.get_all('foo')
         end
@@ -372,7 +372,7 @@ describe Diplomat::Kv do
       context 'datacenter filter' do
         it 'GET_ALL for a specific datacenter' do
           kv = Diplomat::Kv.new
-          stub_request(:get, 'http://localhost:8500/v1/kv/foo?dc=bar&recurse')
+          stub_request(:get, 'http://localhost:8500/v1/kv/foo?dc=bar&recurse=true')
             .to_return(OpenStruct.new(status: 200, body: JSON.generate([])))
           kv.get_all('foo', dc: 'bar')
         end
@@ -535,7 +535,7 @@ describe Diplomat::Kv do
 
       context 'ACLs NOT enabled, recurse option ON' do
         it 'DELETE' do
-          stub_request(:delete, 'http://localhost:8500/v1/kv/key?recurse')
+          stub_request(:delete, 'http://localhost:8500/v1/kv/key?recurse=true')
             .to_return(OpenStruct.new(status: 200))
           kv = Diplomat::Kv.new
           expect(kv.delete(key, recurse: true).status).to eq(200)


### PR DESCRIPTION
This is doing a couple things to bring this gem more in alignment with the expectations of the Consul API:

1. It is generalizing the Faraday connection to always use `FlatParamsEncoder`. This is because Consul's API has already taken the stance that they do not expect multiple params to be specified using `[]` but instead by simply repeating the same query param multiple times.
2. Adding support to `Diplomat::Health.service` for specifying an array of tags when querying for a service's health checks

Fixes #212 