### PR TITLE
Add blocking query support for service health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+* Added ability to specify `index` as a query option for service health
+* Added ability to receive meta data back from service health queries
+
 ## 2.5.1
 
 * Do not force users to use faraday 1.3+ to fix https://github.com/sous-chefs/consul/issues/582

--- a/spec/health_spec.rb
+++ b/spec/health_spec.rb
@@ -213,6 +213,31 @@ describe Diplomat::Health do
       expect(health.service('foobar', options: options).first['Node']['Node']).to eq('foobar')
     end
 
+    it 'checks services with index option' do
+      stub_request(:get, 'http://localhost:8500/v1/health/service/foobar?index=1')
+        .and_return(body: json)
+      health = Diplomat::Health
+
+      expect(health.service('foobar', index: 1).first['Node']['Node']).to eq('foobar')
+    end
+
+    context 'when a metadata hash is provided' do
+      let(:x_consul_index)        { '1424543438' }
+      let(:x_consul_known_leader) { 'true' }
+      let(:x_consul_last_contact) { '0s' }
+
+      it 'populates it with the response header data' do
+        stub_request(:get, 'http://localhost:8500/v1/health/service/foobar')
+          .and_return(body: json, headers: { 'X-Consul-Index' => x_consul_index, 'X-Consul-KnownLeader' => x_consul_known_leader, 'X-Consul-LastContact' => x_consul_last_contact })
+
+        health = Diplomat::Health
+        meta   = {}
+
+        expect(health.service('foobar', {}, meta).first['Node']['Node']).to eq('foobar')
+        expect(meta).to eq({ index: x_consul_index, knownleader: x_consul_known_leader, lastcontact: x_consul_last_contact })
+      end
+    end
+
     it 'should return an array of checks' do
       expect(ch).to be_a_kind_of(Array)
     end

--- a/spec/health_spec.rb
+++ b/spec/health_spec.rb
@@ -225,16 +225,30 @@ describe Diplomat::Health do
       let(:x_consul_index)        { '1424543438' }
       let(:x_consul_known_leader) { 'true' }
       let(:x_consul_last_contact) { '0s' }
+      let(:response_headers) do
+        {
+          'X-Consul-Index' => x_consul_index,
+          'X-Consul-KnownLeader' => x_consul_known_leader,
+          'X-Consul-LastContact' => x_consul_last_contact
+        }
+      end
+      let(:expected_meta_data) do
+        {
+          index: x_consul_index,
+          knownleader: x_consul_known_leader,
+          lastcontact: x_consul_last_contact
+        }
+      end
 
       it 'populates it with the response header data' do
         stub_request(:get, 'http://localhost:8500/v1/health/service/foobar')
-          .and_return(body: json, headers: { 'X-Consul-Index' => x_consul_index, 'X-Consul-KnownLeader' => x_consul_known_leader, 'X-Consul-LastContact' => x_consul_last_contact })
+          .and_return(body: json, headers: response_headers)
 
         health = Diplomat::Health
         meta   = {}
 
         expect(health.service('foobar', {}, meta).first['Node']['Node']).to eq('foobar')
-        expect(meta).to eq({ index: x_consul_index, knownleader: x_consul_known_leader, lastcontact: x_consul_last_contact })
+        expect(meta).to eq(expected_meta_data)
       end
     end
 


### PR DESCRIPTION
This ports similar blocking read support over from `Diplomat::Service.get` so that a similar pattern can be utilized when retrieving service health information.

Fixes #221 