### PR TITLE
Handle Faraday::ServerError in Diplomat::Query#create

### DIFF
--- a/lib/diplomat/query.rb
+++ b/lib/diplomat/query.rb
@@ -32,7 +32,7 @@ module Diplomat
       custom_params = options[:dc] ? use_named_parameter('dc', options[:dc]) : nil
       @raw = send_post_request(@conn, ['/v1/query'], options, definition, custom_params)
       parse_body
-    rescue Faraday::ClientError
+    rescue Faraday::ClientError, Faraday::ServerError
       raise Diplomat::QueryAlreadyExists
     end
 


### PR DESCRIPTION
Fixes WeAreFarmGeek/diplomat#227

Builds on WeAreFarmGeek/diplomat#203

To support Faraday 1.0, `Faraday::ServerError` handling was added to the `Diplomat::RestClient#send_get_request` method.  The Diplomat::Server#create` method should also be updated.

Change passed `rake` with 1.10.1 and 0.17.3