### PR TITLE
add ostruct dependency and ruby 4.0 to ci

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,10 +19,10 @@ jobs:
           ruby-version: '3.2'
       - name: Install dependencies
         run: |
-          gem install bundler
-          bundler install
+          gem install bundler:2.7.2
+          bundle _2.7.2_ install
       - name: Check code
-        run: bundle exec rubocop -c .rubocop.yml
+        run: bundle _2.7.2_ exec rubocop -c .rubocop.yml
 
   test:
     needs: rubocop
@@ -38,11 +38,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          bundler: '2.7.2'
           bundler-cache: true
       - name: Install dependencies
-        run: |
-          gem install bundler
-          bundler install
+        run: bundle install
       - name: Run tests
         run: bundle exec rspec
 
@@ -58,8 +57,8 @@ jobs:
           ruby-version: '3.2'
       - name: Install dependencies
         run: |
-          gem install bundler
-          bundler install
+          gem install bundler:2.7.2
+          bundle _2.7.2_ install
       - name: Build GEM diplomat
         run: gem build diplomat.gemspec
       - name: Build GEM diplomatic_bag

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.2', '3.3', '3.4']
+        ruby-version: ['3.2', '3.3', '3.4', '4.0']
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+* 2026-03-05 Add `ostruct` gem dependency and Ruby 4.0 to CI; OpenStruct was removed from Ruby 4 standard library.
+
 ## 2.6.5 (2025-05-17)
 
 * @mougams added Diplomat::RaftOperator module with methods .get_configuration .transfer_leader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next
 
-* 2026-03-05 Add `ostruct` gem dependency and Ruby 4.0 to CI; OpenStruct was removed from Ruby 4 standard library.
+* 2026-03-05 Add `ostruct` gem dependency and Ruby 4.0 to CI; OpenStruct was removed from Ruby 4 standard library. ([@gavinest](https://github.com/gavinest))
+* 2026-03-07 Fix CI: pin Bundler to 2.7.2 in workflow so it satisfies gemspec `bundler ~> 2.2`. ([@gavinest](https://github.com/gavinest))
 
 ## 2.6.5 (2025-05-17)
 

--- a/diplomat.gemspec
+++ b/diplomat.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new 'diplomat', Diplomat::VERSION do |spec|
   spec.add_development_dependency 'webmock'
 
   spec.add_runtime_dependency 'deep_merge', '~> 1.2'
+  spec.add_runtime_dependency 'ostruct'
 
   # See https://github.com/WeAreFarmGeek/diplomat/issues/223
   # Diplomat does not work with 2.0 of Faraday, but does with 2.0.1+


### PR DESCRIPTION
# summary

* add ruby 4.0 support. 

ruby 4.0 drops ostruct from the standard library.  I added it as dependency in the gemspec file and added ruby 4.0 to the ci matrix.

* fix CI

CI was installing the latest Bundler (4.x) while the gemspec requires bundler ~> 2.2, so we fixed it by pinning the workflow to Bundler 2.7.2 and using that for installs and bundle exec. 